### PR TITLE
Material picker enhancements

### DIFF
--- a/Example/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp.csproj
+++ b/Example/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp.csproj
@@ -42,6 +42,7 @@
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="MainViewModel.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MainPage.xaml">
@@ -63,9 +64,13 @@
     <Reference Include="Xamarin.Forms.Xaml, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
+    <Reference Include="PropertyChanged">
+      <HintPath>..\..\packages\PropertyChanged.Fody.2.1.4\lib\netstandard1.0\PropertyChanged.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="FodyWeavers.xml" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\SuaveControls.MaterialForms\SuaveControls.MaterialForms.csproj">
@@ -81,4 +86,5 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets'))" />
   </Target>
+  <Import Project="..\..\packages\Fody.2.0.0\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\..\packages\Fody.2.0.0\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
 </Project>

--- a/Example/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp/FodyWeavers.xml
+++ b/Example/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp/FodyWeavers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Weavers>
+  <PropertyChanged />
+</Weavers>

--- a/Example/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp/MainPage.xaml
+++ b/Example/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp/MainPage.xaml
@@ -1,9 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:ExampleMaterialApp"
              xmlns:suave="clr-namespace:SuaveControls.MaterialForms;assembly=SuaveControls.MaterialForms"
              x:Class="ExampleMaterialApp.MainPage">
+
+    <ContentPage.BindingContext>
+        <local:MainViewModel />
+    </ContentPage.BindingContext>
 
     <ScrollView>
         <StackLayout Spacing="16" Margin="16">
@@ -14,7 +18,7 @@
             <suave:MaterialEntry IsPassword="True" Placeholder="Password" AccentColor="Blue"/>
             <suave:MaterialDatePicker Placeholder="Date Picker" AccentColor="BlueViolet"/>
             <suave:MaterialTimePicker Placeholder="Time Picker" AccentColor="HotPink" />
-            <suave:MaterialPicker x:Name="PickerDemo" Placeholder="Picker" AccentColor="Maroon"/>
+            <suave:MaterialPicker x:Name="PickerDemo" Placeholder="Picker" AccentColor="Maroon" Items="{Binding PickerData}" />
 
         </StackLayout>
     </ScrollView>

--- a/Example/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp/MainPage.xaml
+++ b/Example/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp/MainPage.xaml
@@ -22,7 +22,8 @@
                 Placeholder="Picker"
                 AccentColor="Maroon"
                 Items="{Binding PickerData}"
-                SelectedItem="{Binding PickerSelectedItem}" />
+                SelectedItem="{Binding PickerSelectedItem}"
+                SelectedIndexChangedCommand="{Binding PickerSelectedIndexChangedCmd}" />
 
         </StackLayout>
     </ScrollView>

--- a/Example/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp/MainPage.xaml
+++ b/Example/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp/MainPage.xaml
@@ -18,7 +18,11 @@
             <suave:MaterialEntry IsPassword="True" Placeholder="Password" AccentColor="Blue"/>
             <suave:MaterialDatePicker Placeholder="Date Picker" AccentColor="BlueViolet"/>
             <suave:MaterialTimePicker Placeholder="Time Picker" AccentColor="HotPink" />
-            <suave:MaterialPicker x:Name="PickerDemo" Placeholder="Picker" AccentColor="Maroon" Items="{Binding PickerData}" />
+            <suave:MaterialPicker 
+                Placeholder="Picker"
+                AccentColor="Maroon"
+                Items="{Binding PickerData}"
+                SelectedItem="{Binding PickerSelectedItem}" />
 
         </StackLayout>
     </ScrollView>

--- a/Example/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp/MainPage.xaml.cs
+++ b/Example/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp/MainPage.xaml.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 
 namespace ExampleMaterialApp
 {
@@ -12,14 +7,6 @@ namespace ExampleMaterialApp
         public MainPage()
         {
             InitializeComponent();
-
-            PickerDemo.Items = new List<string>
-            {
-                "Option 1",
-                "Option 2",
-                "Option 3",
-                "Option 4"
-            };
         }
     }
 }

--- a/Example/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp/MainViewModel.cs
+++ b/Example/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp/MainViewModel.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.ObjectModel;
+using System.ComponentModel;
+
+namespace ExampleMaterialApp
+{
+    public class MainViewModel : INotifyPropertyChanged
+    {
+
+        public ObservableCollection<Fruit> PickerData { get; set; }
+
+        public MainViewModel()
+        {
+            PickerData = new ObservableCollection<Fruit>
+            {
+                new Fruit { Id = 1, Name ="Apple" },
+                new Fruit { Id = 2, Name = "Banana" },
+                new Fruit { Id = 3, Name = "Orange" }
+            };
+        }
+
+        // Fody will take care of that
+        public event PropertyChangedEventHandler PropertyChanged;
+    }
+
+    public class Fruit
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+        public override string ToString() => Name;
+    }
+}

--- a/Example/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp/MainViewModel.cs
+++ b/Example/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp/MainViewModel.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics;
+using System.Windows.Input;
+using Xamarin.Forms;
 
 namespace ExampleMaterialApp
 {
@@ -8,6 +11,7 @@ namespace ExampleMaterialApp
 
         public ObservableCollection<Fruit> PickerData { get; set; }
         public Fruit PickerSelectedItem { get; set; }
+        public ICommand PickerSelectedIndexChangedCmd { get; }
 
         public MainViewModel()
         {
@@ -19,6 +23,8 @@ namespace ExampleMaterialApp
             };
 
             PickerSelectedItem = PickerData[PickerData.Count - 1];
+
+            PickerSelectedIndexChangedCmd = new Command<Fruit>((selectedFruit) => Debug.WriteLine($"PickerSelectedIndexChangedCmd => {selectedFruit}"));
         }
 
         // Fody will take care of that

--- a/Example/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp/MainViewModel.cs
+++ b/Example/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp/MainViewModel.cs
@@ -7,6 +7,7 @@ namespace ExampleMaterialApp
     {
 
         public ObservableCollection<Fruit> PickerData { get; set; }
+        public Fruit PickerSelectedItem { get; set; }
 
         public MainViewModel()
         {
@@ -16,6 +17,8 @@ namespace ExampleMaterialApp
                 new Fruit { Id = 2, Name = "Banana" },
                 new Fruit { Id = 3, Name = "Orange" }
             };
+
+            PickerSelectedItem = PickerData[PickerData.Count - 1];
         }
 
         // Fody will take care of that

--- a/Example/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp/packages.config
+++ b/Example/ExampleMaterialApp/ExampleMaterialApp/ExampleMaterialApp/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Fody" version="2.0.0" targetFramework="portable45-net45+win8+wpa81" developmentDependency="true" />
+  <package id="PropertyChanged.Fody" version="2.1.4" targetFramework="portable45-net45+win8+wpa81" developmentDependency="true" />
   <package id="Xamarin.Forms" version="2.3.4.247" targetFramework="portable45-net45+win8+wp8+wpa81" />
 </packages>

--- a/src/SuaveControls.MaterialForms/MaterialPicker.xaml
+++ b/src/SuaveControls.MaterialForms/MaterialPicker.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ContentView xmlns="http://xamarin.com/schemas/2014/forms" 
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:views="clr-namespace:SuaveControls.MaterialForms"
@@ -9,7 +9,12 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="1"/>
             </Grid.RowDefinitions>
-            <views:BorderlessPicker x:Name="Picker" Margin="0,12,0,0" ItemsSource="{Binding Items}" SelectedIndex="{Binding SelectedIndex, Mode=TwoWay}"/>
+            <views:BorderlessPicker
+                x:Name="Picker"
+                Margin="0,12,0,0"
+                ItemsSource="{Binding Items}"
+                SelectedIndex="{Binding SelectedIndex, Mode=TwoWay}"
+                SelectedItem="{Binding SelectedItem, Mode=TwoWay}" />
             <Label x:Name="HiddenLabel" FontSize="10" IsVisible="False" Margin="0"/>
             <BoxView x:Name="BottomBorder" BackgroundColor="Gray" Grid.Row="1" HeightRequest="1" Margin="0" HorizontalOptions="FillAndExpand"/>
             <BoxView x:Name="HiddenBottomBorder" BackgroundColor="Gray" Grid.Row="1" HeightRequest="1" Margin="0" WidthRequest="0" HorizontalOptions="Center"/>

--- a/src/SuaveControls.MaterialForms/MaterialPicker.xaml
+++ b/src/SuaveControls.MaterialForms/MaterialPicker.xaml
@@ -15,7 +15,11 @@
                 ItemsSource="{Binding Items}"
                 SelectedIndex="{Binding SelectedIndex, Mode=TwoWay}"
                 SelectedItem="{Binding SelectedItem, Mode=TwoWay}" />
-            <Label x:Name="HiddenLabel" FontSize="10" IsVisible="False" Margin="0"/>
+            <Label x:Name="HiddenLabel"
+                FontSize="10"
+                IsVisible="False"
+                Margin="0"
+                VerticalOptions="Start" />
             <BoxView x:Name="BottomBorder" BackgroundColor="Gray" Grid.Row="1" HeightRequest="1" Margin="0" HorizontalOptions="FillAndExpand"/>
             <BoxView x:Name="HiddenBottomBorder" BackgroundColor="Gray" Grid.Row="1" HeightRequest="1" Margin="0" WidthRequest="0" HorizontalOptions="Center"/>
         </Grid>

--- a/src/SuaveControls.MaterialForms/MaterialPicker.xaml.cs
+++ b/src/SuaveControls.MaterialForms/MaterialPicker.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using Xamarin.Forms;
 
 namespace SuaveControls.MaterialForms
@@ -21,6 +22,13 @@ namespace SuaveControls.MaterialForms
             var matPicker = (MaterialPicker)bindable;
 			matPicker.HiddenLabel.IsVisible = !string.IsNullOrEmpty(newValue?.ToString());
         });
+        public static BindableProperty SelectedIndexChangedCommandProperty = BindableProperty.Create(nameof(SelectedIndexChangedCommand), typeof(ICommand), typeof(MaterialPicker), null);
+
+        public ICommand SelectedIndexChangedCommand
+        {
+            get { return (ICommand)GetValue(SelectedIndexChangedCommandProperty); }
+			set { SetValue(SelectedIndexChangedCommandProperty, value); }
+        }
 
 		public object SelectedItem
 		{
@@ -92,6 +100,12 @@ namespace SuaveControls.MaterialForms
         {
             InitializeComponent();
             Picker.BindingContext = this;
+            // TODO: Possible memory leak?
+            Picker.SelectedIndexChanged += (sender, e) => 
+            {
+                SelectedIndexChangedCommand?.Execute(Picker.SelectedItem);
+            };
+
             Picker.Focused += async (s, a) =>
             {
                 HiddenBottomBorder.BackgroundColor = AccentColor;
@@ -134,5 +148,7 @@ namespace SuaveControls.MaterialForms
         }
 
         public Picker GetUnderlyingPicker() => Picker;
+
+
     }
 }

--- a/src/SuaveControls.MaterialForms/MaterialPicker.xaml.cs
+++ b/src/SuaveControls.MaterialForms/MaterialPicker.xaml.cs
@@ -9,13 +9,20 @@ namespace SuaveControls.MaterialForms
         public static BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(MaterialPicker), defaultBindingMode: BindingMode.TwoWay);
         public static BindableProperty PlaceholderProperty = BindableProperty.Create(nameof(Placeholder), typeof(string), typeof(MaterialPicker), defaultBindingMode: BindingMode.TwoWay, propertyChanged: (bindable, oldVal, newval) =>
         {
-            var matEntry = (MaterialPicker)bindable;
-            matEntry.Picker.Title = (string)newval;
-            matEntry.HiddenLabel.Text = (string)newval;
+            var matPicker = (MaterialPicker)bindable;
+            matPicker.Picker.Title = (string)newval;
+            matPicker.HiddenLabel.Text = (string)newval;
         });
         public static BindableProperty ItemsProperty = BindableProperty.Create(nameof(Items), typeof(IList), typeof(MaterialPicker), null);
         public static BindableProperty SelectedIndexProperty = BindableProperty.Create(nameof(SelectedIndex), typeof(int), typeof(MaterialPicker), 0, BindingMode.TwoWay);
         public static BindableProperty AccentColorProperty = BindableProperty.Create(nameof(AccentColor), typeof(Color), typeof(MaterialPicker), defaultValue: Color.Accent);
+        public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create(nameof(SelectedItem), typeof(object), typeof(MaterialPicker), null, BindingMode.TwoWay);
+
+		public object SelectedItem
+		{
+			get { return GetValue(SelectedItemProperty); }
+			set { SetValue(SelectedItemProperty, value); }
+		}
 
         public int SelectedIndex
         {
@@ -122,9 +129,6 @@ namespace SuaveControls.MaterialForms
 
         }
 
-        public Picker GetUnderlyingPicker()
-        {
-            return Picker;
-        }
+        public Picker GetUnderlyingPicker() => Picker;
     }
 }

--- a/src/SuaveControls.MaterialForms/MaterialPicker.xaml.cs
+++ b/src/SuaveControls.MaterialForms/MaterialPicker.xaml.cs
@@ -16,7 +16,11 @@ namespace SuaveControls.MaterialForms
         public static BindableProperty ItemsProperty = BindableProperty.Create(nameof(Items), typeof(IList), typeof(MaterialPicker), null);
         public static BindableProperty SelectedIndexProperty = BindableProperty.Create(nameof(SelectedIndex), typeof(int), typeof(MaterialPicker), 0, BindingMode.TwoWay);
         public static BindableProperty AccentColorProperty = BindableProperty.Create(nameof(AccentColor), typeof(Color), typeof(MaterialPicker), defaultValue: Color.Accent);
-        public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create(nameof(SelectedItem), typeof(object), typeof(MaterialPicker), null, BindingMode.TwoWay);
+        public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create(nameof(SelectedItem), typeof(object), typeof(MaterialPicker), null, BindingMode.TwoWay, propertyChanged: (bindable, oldValue, newValue) => 
+        {
+            var matPicker = (MaterialPicker)bindable;
+			matPicker.HiddenLabel.IsVisible = !string.IsNullOrEmpty(newValue?.ToString());
+        });
 
 		public object SelectedItem
 		{

--- a/src/SuaveControls.MaterialForms/MaterialPicker.xaml.cs
+++ b/src/SuaveControls.MaterialForms/MaterialPicker.xaml.cs
@@ -1,18 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections;
 using System.Threading.Tasks;
-
 using Xamarin.Forms;
-using Xamarin.Forms.Xaml;
 
 namespace SuaveControls.MaterialForms
 {
     public partial class MaterialPicker : ContentView
     {
-
-
         public static BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(MaterialPicker), defaultBindingMode: BindingMode.TwoWay);
         public static BindableProperty PlaceholderProperty = BindableProperty.Create(nameof(Placeholder), typeof(string), typeof(MaterialPicker), defaultBindingMode: BindingMode.TwoWay, propertyChanged: (bindable, oldVal, newval) =>
         {
@@ -20,7 +13,7 @@ namespace SuaveControls.MaterialForms
             matEntry.Picker.Title = (string)newval;
             matEntry.HiddenLabel.Text = (string)newval;
         });
-        public static BindableProperty ItemsProperty = BindableProperty.Create(nameof(Items), typeof(List<string>), typeof(MaterialPicker), null);
+        public static BindableProperty ItemsProperty = BindableProperty.Create(nameof(Items), typeof(IList), typeof(MaterialPicker), null);
         public static BindableProperty SelectedIndexProperty = BindableProperty.Create(nameof(SelectedIndex), typeof(int), typeof(MaterialPicker), 0, BindingMode.TwoWay);
         public static BindableProperty AccentColorProperty = BindableProperty.Create(nameof(AccentColor), typeof(Color), typeof(MaterialPicker), defaultValue: Color.Accent);
 
@@ -36,11 +29,11 @@ namespace SuaveControls.MaterialForms
             }
         }
 
-        public List<string> Items
+        public IList Items
         {
             get
             {
-                return (List<string>)GetValue(ItemsProperty);
+                return (IList)GetValue(ItemsProperty);
             }
             set
             {
@@ -71,6 +64,7 @@ namespace SuaveControls.MaterialForms
                 SetValue(TextProperty, value);
             }
         }
+
         public string Placeholder
         {
             get
@@ -82,6 +76,7 @@ namespace SuaveControls.MaterialForms
                 SetValue(PlaceholderProperty, value);
             }
         }
+
         public MaterialPicker()
         {
             InitializeComponent();
@@ -131,7 +126,5 @@ namespace SuaveControls.MaterialForms
         {
             return Picker;
         }
-
-
     }
 }


### PR DESCRIPTION
Based on #6 MaterialPicker Enhancements

**Bugs fixed:**
1. HiddenLabel visible only after Picker Focused() event.
2. On iOS HiddenLabel is overlapping the Picker control, which makes the Picker not responsive.

**New features:**
1.  Generic ItemsSource.
2. Bindable 'SelectedItemProperty' property.
3. Bindable 'SelectedIndexChangedCommand' property, hooked to Picker.SelectedIndexChanged. 

Generally, I had to change the example app, to test bindings. Now it contains a MainViewModel and MaterialPicker related stuff is hosted in the VM.

P.S.: Not tested on UWP.