### PR TITLE
[Issue] MaterialDatePicker| Android | Today's Date not working

### DIFF
--- a/src/SuaveControls.MaterialForms/MaterialDatePicker.xaml.cs
+++ b/src/SuaveControls.MaterialForms/MaterialDatePicker.xaml.cs
@@ -130,6 +130,9 @@ namespace SuaveControls.MaterialForms
                 HiddenBottomBorder.BackgroundColor = AccentColor;
                 HiddenLabel.TextColor = AccentColor;
                 HiddenLabel.IsVisible = true;
+		if (string.IsNullOrEmpty(CustomDateFormat))
+                    CustomDateFormat = _defaultDateFormat;
+                EntryField.Text = Picker.Date.ToString(CustomDateFormat, CultureInfo.CurrentCulture);
                 if (string.IsNullOrEmpty(EntryField.Text))
                 {
                     // animate both at the same time
@@ -165,12 +168,6 @@ namespace SuaveControls.MaterialForms
             };
 
             Picker.DateSelected += Picker_DateSelected;
-	    
-	    /* Set Today's date as Initial Value */
-            if (string.IsNullOrEmpty(CustomDateFormat))
-                CustomDateFormat = _defaultDateFormat;
-            Picker.Date = new DateTime(DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day);
-            EntryField.Text = Picker.Date.ToString(CustomDateFormat, CultureInfo.CurrentCulture);
         }
 
         private void Picker_DateSelected(object sender, DateChangedEventArgs e)

--- a/src/SuaveControls.MaterialForms/MaterialDatePicker.xaml.cs
+++ b/src/SuaveControls.MaterialForms/MaterialDatePicker.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -12,7 +13,19 @@ namespace SuaveControls.MaterialForms
     public partial class MaterialDatePicker : ContentView
     {
 
-
+        public static BindableProperty CustomDateFormatProperty = BindableProperty.Create(nameof(CustomDateFormat), typeof(string), typeof(MaterialDatePicker), defaultBindingMode: BindingMode.TwoWay);
+        public string CustomDateFormat
+        {
+            get
+            {
+                return (string)GetValue(CustomDateFormatProperty);
+            }
+            set
+            {
+                SetValue(CustomDateFormatProperty, value);
+            }
+        }
+        private static string _defaultDateFormat = "dddd, MMMM d, yyyy";
         public static BindableProperty DateProperty = BindableProperty.Create(nameof(Date), typeof(DateTime?), typeof(MaterialDatePicker), defaultBindingMode: BindingMode.TwoWay);
         public static BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(MaterialDatePicker), defaultBindingMode: BindingMode.TwoWay);
         public static BindableProperty PlaceholderProperty = BindableProperty.Create(nameof(Placeholder), typeof(string), typeof(MaterialDatePicker), defaultBindingMode: BindingMode.TwoWay, propertyChanged: (bindable, oldVal, newval) =>
@@ -152,11 +165,19 @@ namespace SuaveControls.MaterialForms
             };
 
             Picker.DateSelected += Picker_DateSelected;
+	    
+	    /* Set Today's date as Initial Value */
+            if (string.IsNullOrEmpty(CustomDateFormat))
+                CustomDateFormat = _defaultDateFormat;
+            Picker.Date = new DateTime(DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day);
+            EntryField.Text = Picker.Date.ToString(CustomDateFormat, CultureInfo.CurrentCulture);
         }
 
         private void Picker_DateSelected(object sender, DateChangedEventArgs e)
         {
-            EntryField.Text = e.NewDate.ToString("dddd, MMMM d, yyyy");
+            if (string.IsNullOrEmpty(CustomDateFormat))
+                CustomDateFormat = _defaultDateFormat;
+            EntryField.Text = e.NewDate.ToString(CustomDateFormat, CultureInfo.CurrentCulture);
             Date = e.NewDate;
         }
     }


### PR DESCRIPTION
If I select today’s date in Android, It is showing as empty. So I need to select another date and then select today’s date.

Steps:

    If DatePicker is clicked, It popup with selected as today's date. Click Ok.
    It is not firing "Picker_DateSelected".


Added ability for Custom Date Format

--------------
Note: This still has one issue, Even if "Cancel" is clicked, It will populate with "Selected" date.