### PR TITLE
.Net standard 2.0 support has been implemented

### DIFF
--- a/src/SuaveControls.MaterialForms.Android/Resources/Resource.Designer.cs
+++ b/src/SuaveControls.MaterialForms.Android/Resources/Resource.Designer.cs
@@ -64,16 +64,16 @@ namespace SuaveControls.MaterialForms.Android
 			public static int design_bottom_sheet_slide_out = 2130968587;
 			
 			// aapt resource value: 0x7f04000c
-			public static int design_fab_in = 2130968588;
+			public static int design_snackbar_in = 2130968588;
 			
 			// aapt resource value: 0x7f04000d
-			public static int design_fab_out = 2130968589;
+			public static int design_snackbar_out = 2130968589;
 			
 			// aapt resource value: 0x7f04000e
-			public static int design_snackbar_in = 2130968590;
+			public static int tooltip_enter = 2130968590;
 			
 			// aapt resource value: 0x7f04000f
-			public static int design_snackbar_out = 2130968591;
+			public static int tooltip_exit = 2130968591;
 			
 			static Animation()
 			{
@@ -85,956 +85,1137 @@ namespace SuaveControls.MaterialForms.Android
 			}
 		}
 		
+		public partial class Animator
+		{
+			
+			// aapt resource value: 0x7f050000
+			public static int design_appbar_state_list_animator = 2131034112;
+			
+			static Animator()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Animator()
+			{
+			}
+		}
+		
 		public partial class Attribute
 		{
 			
-			// aapt resource value: 0x7f010004
-			public static int MediaRouteControllerWindowBackground = 2130771972;
-			
-			// aapt resource value: 0x7f010061
-			public static int actionBarDivider = 2130772065;
-			
-			// aapt resource value: 0x7f010062
-			public static int actionBarItemBackground = 2130772066;
-			
-			// aapt resource value: 0x7f01005b
-			public static int actionBarPopupTheme = 2130772059;
-			
-			// aapt resource value: 0x7f010060
-			public static int actionBarSize = 2130772064;
-			
-			// aapt resource value: 0x7f01005d
-			public static int actionBarSplitStyle = 2130772061;
-			
-			// aapt resource value: 0x7f01005c
-			public static int actionBarStyle = 2130772060;
-			
-			// aapt resource value: 0x7f010057
-			public static int actionBarTabBarStyle = 2130772055;
-			
-			// aapt resource value: 0x7f010056
-			public static int actionBarTabStyle = 2130772054;
-			
-			// aapt resource value: 0x7f010058
-			public static int actionBarTabTextStyle = 2130772056;
-			
-			// aapt resource value: 0x7f01005e
-			public static int actionBarTheme = 2130772062;
-			
-			// aapt resource value: 0x7f01005f
-			public static int actionBarWidgetTheme = 2130772063;
-			
-			// aapt resource value: 0x7f01007b
-			public static int actionButtonStyle = 2130772091;
-			
-			// aapt resource value: 0x7f010077
-			public static int actionDropDownStyle = 2130772087;
-			
-			// aapt resource value: 0x7f0100c9
-			public static int actionLayout = 2130772169;
-			
-			// aapt resource value: 0x7f010063
-			public static int actionMenuTextAppearance = 2130772067;
-			
-			// aapt resource value: 0x7f010064
-			public static int actionMenuTextColor = 2130772068;
-			
-			// aapt resource value: 0x7f010067
-			public static int actionModeBackground = 2130772071;
-			
-			// aapt resource value: 0x7f010066
-			public static int actionModeCloseButtonStyle = 2130772070;
-			
-			// aapt resource value: 0x7f010069
-			public static int actionModeCloseDrawable = 2130772073;
-			
 			// aapt resource value: 0x7f01006b
-			public static int actionModeCopyDrawable = 2130772075;
-			
-			// aapt resource value: 0x7f01006a
-			public static int actionModeCutDrawable = 2130772074;
-			
-			// aapt resource value: 0x7f01006f
-			public static int actionModeFindDrawable = 2130772079;
+			public static int actionBarDivider = 2130772075;
 			
 			// aapt resource value: 0x7f01006c
-			public static int actionModePasteDrawable = 2130772076;
-			
-			// aapt resource value: 0x7f010071
-			public static int actionModePopupWindowStyle = 2130772081;
-			
-			// aapt resource value: 0x7f01006d
-			public static int actionModeSelectAllDrawable = 2130772077;
-			
-			// aapt resource value: 0x7f01006e
-			public static int actionModeShareDrawable = 2130772078;
-			
-			// aapt resource value: 0x7f010068
-			public static int actionModeSplitBackground = 2130772072;
+			public static int actionBarItemBackground = 2130772076;
 			
 			// aapt resource value: 0x7f010065
-			public static int actionModeStyle = 2130772069;
+			public static int actionBarPopupTheme = 2130772069;
 			
-			// aapt resource value: 0x7f010070
-			public static int actionModeWebSearchDrawable = 2130772080;
+			// aapt resource value: 0x7f01006a
+			public static int actionBarSize = 2130772074;
 			
-			// aapt resource value: 0x7f010059
-			public static int actionOverflowButtonStyle = 2130772057;
+			// aapt resource value: 0x7f010067
+			public static int actionBarSplitStyle = 2130772071;
 			
-			// aapt resource value: 0x7f01005a
-			public static int actionOverflowMenuStyle = 2130772058;
+			// aapt resource value: 0x7f010066
+			public static int actionBarStyle = 2130772070;
 			
-			// aapt resource value: 0x7f0100cb
-			public static int actionProviderClass = 2130772171;
+			// aapt resource value: 0x7f010061
+			public static int actionBarTabBarStyle = 2130772065;
 			
-			// aapt resource value: 0x7f0100ca
-			public static int actionViewClass = 2130772170;
+			// aapt resource value: 0x7f010060
+			public static int actionBarTabStyle = 2130772064;
 			
-			// aapt resource value: 0x7f010083
-			public static int activityChooserViewStyle = 2130772099;
+			// aapt resource value: 0x7f010062
+			public static int actionBarTabTextStyle = 2130772066;
 			
-			// aapt resource value: 0x7f0100a6
-			public static int alertDialogButtonGroupStyle = 2130772134;
+			// aapt resource value: 0x7f010068
+			public static int actionBarTheme = 2130772072;
 			
-			// aapt resource value: 0x7f0100a7
-			public static int alertDialogCenterButtons = 2130772135;
+			// aapt resource value: 0x7f010069
+			public static int actionBarWidgetTheme = 2130772073;
 			
-			// aapt resource value: 0x7f0100a5
-			public static int alertDialogStyle = 2130772133;
-			
-			// aapt resource value: 0x7f0100a8
-			public static int alertDialogTheme = 2130772136;
-			
-			// aapt resource value: 0x7f0100ba
-			public static int allowStacking = 2130772154;
-			
-			// aapt resource value: 0x7f0100c1
-			public static int arrowHeadLength = 2130772161;
-			
-			// aapt resource value: 0x7f0100c2
-			public static int arrowShaftLength = 2130772162;
-			
-			// aapt resource value: 0x7f0100ad
-			public static int autoCompleteTextViewStyle = 2130772141;
-			
-			// aapt resource value: 0x7f010032
-			public static int background = 2130772018;
-			
-			// aapt resource value: 0x7f010034
-			public static int backgroundSplit = 2130772020;
-			
-			// aapt resource value: 0x7f010033
-			public static int backgroundStacked = 2130772019;
-			
-			// aapt resource value: 0x7f0100f5
-			public static int backgroundTint = 2130772213;
-			
-			// aapt resource value: 0x7f0100f6
-			public static int backgroundTintMode = 2130772214;
-			
-			// aapt resource value: 0x7f0100c3
-			public static int barLength = 2130772163;
-			
-			// aapt resource value: 0x7f0100fb
-			public static int behavior_hideable = 2130772219;
-			
-			// aapt resource value: 0x7f010121
-			public static int behavior_overlapTop = 2130772257;
-			
-			// aapt resource value: 0x7f0100fa
-			public static int behavior_peekHeight = 2130772218;
-			
-			// aapt resource value: 0x7f010117
-			public static int borderWidth = 2130772247;
-			
-			// aapt resource value: 0x7f010080
-			public static int borderlessButtonStyle = 2130772096;
-			
-			// aapt resource value: 0x7f010111
-			public static int bottomSheetDialogTheme = 2130772241;
-			
-			// aapt resource value: 0x7f010112
-			public static int bottomSheetStyle = 2130772242;
-			
-			// aapt resource value: 0x7f01007d
-			public static int buttonBarButtonStyle = 2130772093;
-			
-			// aapt resource value: 0x7f0100ab
-			public static int buttonBarNegativeButtonStyle = 2130772139;
-			
-			// aapt resource value: 0x7f0100ac
-			public static int buttonBarNeutralButtonStyle = 2130772140;
-			
-			// aapt resource value: 0x7f0100aa
-			public static int buttonBarPositiveButtonStyle = 2130772138;
-			
-			// aapt resource value: 0x7f01007c
-			public static int buttonBarStyle = 2130772092;
-			
-			// aapt resource value: 0x7f010045
-			public static int buttonPanelSideLayout = 2130772037;
-			
-			// aapt resource value: 0x7f0100ae
-			public static int buttonStyle = 2130772142;
-			
-			// aapt resource value: 0x7f0100af
-			public static int buttonStyleSmall = 2130772143;
-			
-			// aapt resource value: 0x7f0100bb
-			public static int buttonTint = 2130772155;
-			
-			// aapt resource value: 0x7f0100bc
-			public static int buttonTintMode = 2130772156;
-			
-			// aapt resource value: 0x7f01001b
-			public static int cardBackgroundColor = 2130771995;
-			
-			// aapt resource value: 0x7f01001c
-			public static int cardCornerRadius = 2130771996;
-			
-			// aapt resource value: 0x7f01001d
-			public static int cardElevation = 2130771997;
-			
-			// aapt resource value: 0x7f01001e
-			public static int cardMaxElevation = 2130771998;
-			
-			// aapt resource value: 0x7f010020
-			public static int cardPreventCornerOverlap = 2130772000;
-			
-			// aapt resource value: 0x7f01001f
-			public static int cardUseCompatPadding = 2130771999;
-			
-			// aapt resource value: 0x7f0100b0
-			public static int checkboxStyle = 2130772144;
-			
-			// aapt resource value: 0x7f0100b1
-			public static int checkedTextViewStyle = 2130772145;
-			
-			// aapt resource value: 0x7f0100d3
-			public static int closeIcon = 2130772179;
-			
-			// aapt resource value: 0x7f010042
-			public static int closeItemLayout = 2130772034;
-			
-			// aapt resource value: 0x7f0100ec
-			public static int collapseContentDescription = 2130772204;
-			
-			// aapt resource value: 0x7f0100eb
-			public static int collapseIcon = 2130772203;
-			
-			// aapt resource value: 0x7f010108
-			public static int collapsedTitleGravity = 2130772232;
-			
-			// aapt resource value: 0x7f010104
-			public static int collapsedTitleTextAppearance = 2130772228;
-			
-			// aapt resource value: 0x7f0100bd
-			public static int color = 2130772157;
-			
-			// aapt resource value: 0x7f01009e
-			public static int colorAccent = 2130772126;
-			
-			// aapt resource value: 0x7f0100a2
-			public static int colorButtonNormal = 2130772130;
-			
-			// aapt resource value: 0x7f0100a0
-			public static int colorControlActivated = 2130772128;
-			
-			// aapt resource value: 0x7f0100a1
-			public static int colorControlHighlight = 2130772129;
-			
-			// aapt resource value: 0x7f01009f
-			public static int colorControlNormal = 2130772127;
-			
-			// aapt resource value: 0x7f01009c
-			public static int colorPrimary = 2130772124;
-			
-			// aapt resource value: 0x7f01009d
-			public static int colorPrimaryDark = 2130772125;
-			
-			// aapt resource value: 0x7f0100a3
-			public static int colorSwitchThumbNormal = 2130772131;
-			
-			// aapt resource value: 0x7f0100d8
-			public static int commitIcon = 2130772184;
-			
-			// aapt resource value: 0x7f01003d
-			public static int contentInsetEnd = 2130772029;
-			
-			// aapt resource value: 0x7f01003e
-			public static int contentInsetLeft = 2130772030;
-			
-			// aapt resource value: 0x7f01003f
-			public static int contentInsetRight = 2130772031;
-			
-			// aapt resource value: 0x7f01003c
-			public static int contentInsetStart = 2130772028;
-			
-			// aapt resource value: 0x7f010021
-			public static int contentPadding = 2130772001;
-			
-			// aapt resource value: 0x7f010025
-			public static int contentPaddingBottom = 2130772005;
-			
-			// aapt resource value: 0x7f010022
-			public static int contentPaddingLeft = 2130772002;
-			
-			// aapt resource value: 0x7f010023
-			public static int contentPaddingRight = 2130772003;
-			
-			// aapt resource value: 0x7f010024
-			public static int contentPaddingTop = 2130772004;
-			
-			// aapt resource value: 0x7f010105
-			public static int contentScrim = 2130772229;
-			
-			// aapt resource value: 0x7f0100a4
-			public static int controlBackground = 2130772132;
-			
-			// aapt resource value: 0x7f010137
-			public static int counterEnabled = 2130772279;
-			
-			// aapt resource value: 0x7f010138
-			public static int counterMaxLength = 2130772280;
-			
-			// aapt resource value: 0x7f01013a
-			public static int counterOverflowTextAppearance = 2130772282;
-			
-			// aapt resource value: 0x7f010139
-			public static int counterTextAppearance = 2130772281;
-			
-			// aapt resource value: 0x7f010035
-			public static int customNavigationLayout = 2130772021;
-			
-			// aapt resource value: 0x7f0100d2
-			public static int defaultQueryHint = 2130772178;
-			
-			// aapt resource value: 0x7f010075
-			public static int dialogPreferredPadding = 2130772085;
-			
-			// aapt resource value: 0x7f010074
-			public static int dialogTheme = 2130772084;
-			
-			// aapt resource value: 0x7f01002b
-			public static int displayOptions = 2130772011;
-			
-			// aapt resource value: 0x7f010031
-			public static int divider = 2130772017;
+			// aapt resource value: 0x7f010086
+			public static int actionButtonStyle = 2130772102;
 			
 			// aapt resource value: 0x7f010082
-			public static int dividerHorizontal = 2130772098;
+			public static int actionDropDownStyle = 2130772098;
 			
-			// aapt resource value: 0x7f0100c7
-			public static int dividerPadding = 2130772167;
+			// aapt resource value: 0x7f0100dd
+			public static int actionLayout = 2130772189;
 			
-			// aapt resource value: 0x7f010081
-			public static int dividerVertical = 2130772097;
+			// aapt resource value: 0x7f01006d
+			public static int actionMenuTextAppearance = 2130772077;
 			
-			// aapt resource value: 0x7f0100bf
-			public static int drawableSize = 2130772159;
+			// aapt resource value: 0x7f01006e
+			public static int actionMenuTextColor = 2130772078;
 			
-			// aapt resource value: 0x7f010026
-			public static int drawerArrowStyle = 2130772006;
+			// aapt resource value: 0x7f010071
+			public static int actionModeBackground = 2130772081;
 			
-			// aapt resource value: 0x7f010094
-			public static int dropDownListViewStyle = 2130772116;
+			// aapt resource value: 0x7f010070
+			public static int actionModeCloseButtonStyle = 2130772080;
+			
+			// aapt resource value: 0x7f010073
+			public static int actionModeCloseDrawable = 2130772083;
+			
+			// aapt resource value: 0x7f010075
+			public static int actionModeCopyDrawable = 2130772085;
+			
+			// aapt resource value: 0x7f010074
+			public static int actionModeCutDrawable = 2130772084;
+			
+			// aapt resource value: 0x7f010079
+			public static int actionModeFindDrawable = 2130772089;
+			
+			// aapt resource value: 0x7f010076
+			public static int actionModePasteDrawable = 2130772086;
+			
+			// aapt resource value: 0x7f01007b
+			public static int actionModePopupWindowStyle = 2130772091;
+			
+			// aapt resource value: 0x7f010077
+			public static int actionModeSelectAllDrawable = 2130772087;
 			
 			// aapt resource value: 0x7f010078
-			public static int dropdownListPreferredItemHeight = 2130772088;
+			public static int actionModeShareDrawable = 2130772088;
 			
-			// aapt resource value: 0x7f010089
-			public static int editTextBackground = 2130772105;
+			// aapt resource value: 0x7f010072
+			public static int actionModeSplitBackground = 2130772082;
 			
-			// aapt resource value: 0x7f010088
-			public static int editTextColor = 2130772104;
-			
-			// aapt resource value: 0x7f0100b2
-			public static int editTextStyle = 2130772146;
-			
-			// aapt resource value: 0x7f010040
-			public static int elevation = 2130772032;
-			
-			// aapt resource value: 0x7f010135
-			public static int errorEnabled = 2130772277;
-			
-			// aapt resource value: 0x7f010136
-			public static int errorTextAppearance = 2130772278;
-			
-			// aapt resource value: 0x7f010044
-			public static int expandActivityOverflowButtonDrawable = 2130772036;
-			
-			// aapt resource value: 0x7f0100f7
-			public static int expanded = 2130772215;
-			
-			// aapt resource value: 0x7f010109
-			public static int expandedTitleGravity = 2130772233;
-			
-			// aapt resource value: 0x7f0100fe
-			public static int expandedTitleMargin = 2130772222;
-			
-			// aapt resource value: 0x7f010102
-			public static int expandedTitleMarginBottom = 2130772226;
-			
-			// aapt resource value: 0x7f010101
-			public static int expandedTitleMarginEnd = 2130772225;
-			
-			// aapt resource value: 0x7f0100ff
-			public static int expandedTitleMarginStart = 2130772223;
-			
-			// aapt resource value: 0x7f010100
-			public static int expandedTitleMarginTop = 2130772224;
-			
-			// aapt resource value: 0x7f010103
-			public static int expandedTitleTextAppearance = 2130772227;
-			
-			// aapt resource value: 0x7f01001a
-			public static int externalRouteEnabledDrawable = 2130771994;
-			
-			// aapt resource value: 0x7f010115
-			public static int fabSize = 2130772245;
-			
-			// aapt resource value: 0x7f010119
-			public static int foregroundInsidePadding = 2130772249;
-			
-			// aapt resource value: 0x7f0100c0
-			public static int gapBetweenBars = 2130772160;
-			
-			// aapt resource value: 0x7f0100d4
-			public static int goIcon = 2130772180;
-			
-			// aapt resource value: 0x7f01011f
-			public static int headerLayout = 2130772255;
-			
-			// aapt resource value: 0x7f010027
-			public static int height = 2130772007;
-			
-			// aapt resource value: 0x7f01003b
-			public static int hideOnContentScroll = 2130772027;
-			
-			// aapt resource value: 0x7f01013b
-			public static int hintAnimationEnabled = 2130772283;
-			
-			// aapt resource value: 0x7f010134
-			public static int hintEnabled = 2130772276;
-			
-			// aapt resource value: 0x7f010133
-			public static int hintTextAppearance = 2130772275;
+			// aapt resource value: 0x7f01006f
+			public static int actionModeStyle = 2130772079;
 			
 			// aapt resource value: 0x7f01007a
-			public static int homeAsUpIndicator = 2130772090;
+			public static int actionModeWebSearchDrawable = 2130772090;
 			
-			// aapt resource value: 0x7f010036
-			public static int homeLayout = 2130772022;
+			// aapt resource value: 0x7f010063
+			public static int actionOverflowButtonStyle = 2130772067;
+			
+			// aapt resource value: 0x7f010064
+			public static int actionOverflowMenuStyle = 2130772068;
+			
+			// aapt resource value: 0x7f0100df
+			public static int actionProviderClass = 2130772191;
+			
+			// aapt resource value: 0x7f0100de
+			public static int actionViewClass = 2130772190;
+			
+			// aapt resource value: 0x7f01008e
+			public static int activityChooserViewStyle = 2130772110;
+			
+			// aapt resource value: 0x7f0100b3
+			public static int alertDialogButtonGroupStyle = 2130772147;
+			
+			// aapt resource value: 0x7f0100b4
+			public static int alertDialogCenterButtons = 2130772148;
+			
+			// aapt resource value: 0x7f0100b2
+			public static int alertDialogStyle = 2130772146;
+			
+			// aapt resource value: 0x7f0100b5
+			public static int alertDialogTheme = 2130772149;
+			
+			// aapt resource value: 0x7f0100cb
+			public static int allowStacking = 2130772171;
+			
+			// aapt resource value: 0x7f0100cc
+			public static int alpha = 2130772172;
+			
+			// aapt resource value: 0x7f0100da
+			public static int alphabeticModifiers = 2130772186;
+			
+			// aapt resource value: 0x7f0100d3
+			public static int arrowHeadLength = 2130772179;
+			
+			// aapt resource value: 0x7f0100d4
+			public static int arrowShaftLength = 2130772180;
+			
+			// aapt resource value: 0x7f0100ba
+			public static int autoCompleteTextViewStyle = 2130772154;
+			
+			// aapt resource value: 0x7f010054
+			public static int autoSizeMaxTextSize = 2130772052;
+			
+			// aapt resource value: 0x7f010053
+			public static int autoSizeMinTextSize = 2130772051;
+			
+			// aapt resource value: 0x7f010052
+			public static int autoSizePresetSizes = 2130772050;
+			
+			// aapt resource value: 0x7f010051
+			public static int autoSizeStepGranularity = 2130772049;
+			
+			// aapt resource value: 0x7f010050
+			public static int autoSizeTextType = 2130772048;
+			
+			// aapt resource value: 0x7f01002e
+			public static int background = 2130772014;
+			
+			// aapt resource value: 0x7f010030
+			public static int backgroundSplit = 2130772016;
 			
 			// aapt resource value: 0x7f01002f
-			public static int icon = 2130772015;
+			public static int backgroundStacked = 2130772015;
 			
-			// aapt resource value: 0x7f0100d0
-			public static int iconifiedByDefault = 2130772176;
+			// aapt resource value: 0x7f010116
+			public static int backgroundTint = 2130772246;
 			
-			// aapt resource value: 0x7f01008a
-			public static int imageButtonStyle = 2130772106;
+			// aapt resource value: 0x7f010117
+			public static int backgroundTintMode = 2130772247;
 			
-			// aapt resource value: 0x7f010038
-			public static int indeterminateProgressStyle = 2130772024;
+			// aapt resource value: 0x7f0100d5
+			public static int barLength = 2130772181;
 			
-			// aapt resource value: 0x7f010043
-			public static int initialActivityCount = 2130772035;
-			
-			// aapt resource value: 0x7f010120
-			public static int insetForeground = 2130772256;
-			
-			// aapt resource value: 0x7f010028
-			public static int isLightTheme = 2130772008;
-			
-			// aapt resource value: 0x7f01011d
-			public static int itemBackground = 2130772253;
-			
-			// aapt resource value: 0x7f01011b
-			public static int itemIconTint = 2130772251;
-			
-			// aapt resource value: 0x7f01003a
-			public static int itemPadding = 2130772026;
+			// aapt resource value: 0x7f010141
+			public static int behavior_autoHide = 2130772289;
 			
 			// aapt resource value: 0x7f01011e
-			public static int itemTextAppearance = 2130772254;
+			public static int behavior_hideable = 2130772254;
 			
-			// aapt resource value: 0x7f01011c
-			public static int itemTextColor = 2130772252;
+			// aapt resource value: 0x7f01014a
+			public static int behavior_overlapTop = 2130772298;
+			
+			// aapt resource value: 0x7f01011d
+			public static int behavior_peekHeight = 2130772253;
+			
+			// aapt resource value: 0x7f01011f
+			public static int behavior_skipCollapsed = 2130772255;
+			
+			// aapt resource value: 0x7f01013f
+			public static int borderWidth = 2130772287;
+			
+			// aapt resource value: 0x7f01008b
+			public static int borderlessButtonStyle = 2130772107;
+			
+			// aapt resource value: 0x7f010139
+			public static int bottomSheetDialogTheme = 2130772281;
+			
+			// aapt resource value: 0x7f01013a
+			public static int bottomSheetStyle = 2130772282;
+			
+			// aapt resource value: 0x7f010088
+			public static int buttonBarButtonStyle = 2130772104;
+			
+			// aapt resource value: 0x7f0100b8
+			public static int buttonBarNegativeButtonStyle = 2130772152;
+			
+			// aapt resource value: 0x7f0100b9
+			public static int buttonBarNeutralButtonStyle = 2130772153;
+			
+			// aapt resource value: 0x7f0100b7
+			public static int buttonBarPositiveButtonStyle = 2130772151;
+			
+			// aapt resource value: 0x7f010087
+			public static int buttonBarStyle = 2130772103;
 			
 			// aapt resource value: 0x7f01010b
-			public static int keylines = 2130772235;
+			public static int buttonGravity = 2130772235;
+			
+			// aapt resource value: 0x7f010043
+			public static int buttonPanelSideLayout = 2130772035;
+			
+			// aapt resource value: 0x7f0100bb
+			public static int buttonStyle = 2130772155;
+			
+			// aapt resource value: 0x7f0100bc
+			public static int buttonStyleSmall = 2130772156;
+			
+			// aapt resource value: 0x7f0100cd
+			public static int buttonTint = 2130772173;
+			
+			// aapt resource value: 0x7f0100ce
+			public static int buttonTintMode = 2130772174;
+			
+			// aapt resource value: 0x7f010017
+			public static int cardBackgroundColor = 2130771991;
+			
+			// aapt resource value: 0x7f010018
+			public static int cardCornerRadius = 2130771992;
+			
+			// aapt resource value: 0x7f010019
+			public static int cardElevation = 2130771993;
+			
+			// aapt resource value: 0x7f01001a
+			public static int cardMaxElevation = 2130771994;
+			
+			// aapt resource value: 0x7f01001c
+			public static int cardPreventCornerOverlap = 2130771996;
+			
+			// aapt resource value: 0x7f01001b
+			public static int cardUseCompatPadding = 2130771995;
+			
+			// aapt resource value: 0x7f0100bd
+			public static int checkboxStyle = 2130772157;
+			
+			// aapt resource value: 0x7f0100be
+			public static int checkedTextViewStyle = 2130772158;
+			
+			// aapt resource value: 0x7f0100ee
+			public static int closeIcon = 2130772206;
+			
+			// aapt resource value: 0x7f010040
+			public static int closeItemLayout = 2130772032;
+			
+			// aapt resource value: 0x7f01010d
+			public static int collapseContentDescription = 2130772237;
+			
+			// aapt resource value: 0x7f01010c
+			public static int collapseIcon = 2130772236;
+			
+			// aapt resource value: 0x7f01012c
+			public static int collapsedTitleGravity = 2130772268;
+			
+			// aapt resource value: 0x7f010126
+			public static int collapsedTitleTextAppearance = 2130772262;
 			
 			// aapt resource value: 0x7f0100cf
-			public static int layout = 2130772175;
+			public static int color = 2130772175;
+			
+			// aapt resource value: 0x7f0100aa
+			public static int colorAccent = 2130772138;
+			
+			// aapt resource value: 0x7f0100b1
+			public static int colorBackgroundFloating = 2130772145;
+			
+			// aapt resource value: 0x7f0100ae
+			public static int colorButtonNormal = 2130772142;
+			
+			// aapt resource value: 0x7f0100ac
+			public static int colorControlActivated = 2130772140;
+			
+			// aapt resource value: 0x7f0100ad
+			public static int colorControlHighlight = 2130772141;
+			
+			// aapt resource value: 0x7f0100ab
+			public static int colorControlNormal = 2130772139;
+			
+			// aapt resource value: 0x7f0100ca
+			public static int colorError = 2130772170;
+			
+			// aapt resource value: 0x7f0100a8
+			public static int colorPrimary = 2130772136;
+			
+			// aapt resource value: 0x7f0100a9
+			public static int colorPrimaryDark = 2130772137;
+			
+			// aapt resource value: 0x7f0100af
+			public static int colorSwitchThumbNormal = 2130772143;
+			
+			// aapt resource value: 0x7f0100f3
+			public static int commitIcon = 2130772211;
+			
+			// aapt resource value: 0x7f0100e0
+			public static int contentDescription = 2130772192;
+			
+			// aapt resource value: 0x7f010039
+			public static int contentInsetEnd = 2130772025;
+			
+			// aapt resource value: 0x7f01003d
+			public static int contentInsetEndWithActions = 2130772029;
+			
+			// aapt resource value: 0x7f01003a
+			public static int contentInsetLeft = 2130772026;
+			
+			// aapt resource value: 0x7f01003b
+			public static int contentInsetRight = 2130772027;
+			
+			// aapt resource value: 0x7f010038
+			public static int contentInsetStart = 2130772024;
+			
+			// aapt resource value: 0x7f01003c
+			public static int contentInsetStartWithNavigation = 2130772028;
+			
+			// aapt resource value: 0x7f01001d
+			public static int contentPadding = 2130771997;
+			
+			// aapt resource value: 0x7f010021
+			public static int contentPaddingBottom = 2130772001;
+			
+			// aapt resource value: 0x7f01001e
+			public static int contentPaddingLeft = 2130771998;
+			
+			// aapt resource value: 0x7f01001f
+			public static int contentPaddingRight = 2130771999;
+			
+			// aapt resource value: 0x7f010020
+			public static int contentPaddingTop = 2130772000;
+			
+			// aapt resource value: 0x7f010127
+			public static int contentScrim = 2130772263;
+			
+			// aapt resource value: 0x7f0100b0
+			public static int controlBackground = 2130772144;
+			
+			// aapt resource value: 0x7f010160
+			public static int counterEnabled = 2130772320;
+			
+			// aapt resource value: 0x7f010161
+			public static int counterMaxLength = 2130772321;
+			
+			// aapt resource value: 0x7f010163
+			public static int counterOverflowTextAppearance = 2130772323;
+			
+			// aapt resource value: 0x7f010162
+			public static int counterTextAppearance = 2130772322;
+			
+			// aapt resource value: 0x7f010031
+			public static int customNavigationLayout = 2130772017;
+			
+			// aapt resource value: 0x7f0100ed
+			public static int defaultQueryHint = 2130772205;
+			
+			// aapt resource value: 0x7f010080
+			public static int dialogPreferredPadding = 2130772096;
+			
+			// aapt resource value: 0x7f01007f
+			public static int dialogTheme = 2130772095;
+			
+			// aapt resource value: 0x7f010027
+			public static int displayOptions = 2130772007;
+			
+			// aapt resource value: 0x7f01002d
+			public static int divider = 2130772013;
+			
+			// aapt resource value: 0x7f01008d
+			public static int dividerHorizontal = 2130772109;
+			
+			// aapt resource value: 0x7f0100d9
+			public static int dividerPadding = 2130772185;
+			
+			// aapt resource value: 0x7f01008c
+			public static int dividerVertical = 2130772108;
+			
+			// aapt resource value: 0x7f0100d1
+			public static int drawableSize = 2130772177;
+			
+			// aapt resource value: 0x7f010022
+			public static int drawerArrowStyle = 2130772002;
+			
+			// aapt resource value: 0x7f01009f
+			public static int dropDownListViewStyle = 2130772127;
+			
+			// aapt resource value: 0x7f010083
+			public static int dropdownListPreferredItemHeight = 2130772099;
+			
+			// aapt resource value: 0x7f010094
+			public static int editTextBackground = 2130772116;
+			
+			// aapt resource value: 0x7f010093
+			public static int editTextColor = 2130772115;
+			
+			// aapt resource value: 0x7f0100bf
+			public static int editTextStyle = 2130772159;
+			
+			// aapt resource value: 0x7f01003e
+			public static int elevation = 2130772030;
+			
+			// aapt resource value: 0x7f01015e
+			public static int errorEnabled = 2130772318;
+			
+			// aapt resource value: 0x7f01015f
+			public static int errorTextAppearance = 2130772319;
+			
+			// aapt resource value: 0x7f010042
+			public static int expandActivityOverflowButtonDrawable = 2130772034;
+			
+			// aapt resource value: 0x7f010118
+			public static int expanded = 2130772248;
+			
+			// aapt resource value: 0x7f01012d
+			public static int expandedTitleGravity = 2130772269;
+			
+			// aapt resource value: 0x7f010120
+			public static int expandedTitleMargin = 2130772256;
+			
+			// aapt resource value: 0x7f010124
+			public static int expandedTitleMarginBottom = 2130772260;
+			
+			// aapt resource value: 0x7f010123
+			public static int expandedTitleMarginEnd = 2130772259;
+			
+			// aapt resource value: 0x7f010121
+			public static int expandedTitleMarginStart = 2130772257;
+			
+			// aapt resource value: 0x7f010122
+			public static int expandedTitleMarginTop = 2130772258;
+			
+			// aapt resource value: 0x7f010125
+			public static int expandedTitleTextAppearance = 2130772261;
+			
+			// aapt resource value: 0x7f010015
+			public static int externalRouteEnabledDrawable = 2130771989;
+			
+			// aapt resource value: 0x7f01013d
+			public static int fabSize = 2130772285;
+			
+			// aapt resource value: 0x7f010004
+			public static int fastScrollEnabled = 2130771972;
+			
+			// aapt resource value: 0x7f010007
+			public static int fastScrollHorizontalThumbDrawable = 2130771975;
+			
+			// aapt resource value: 0x7f010008
+			public static int fastScrollHorizontalTrackDrawable = 2130771976;
+			
+			// aapt resource value: 0x7f010005
+			public static int fastScrollVerticalThumbDrawable = 2130771973;
+			
+			// aapt resource value: 0x7f010006
+			public static int fastScrollVerticalTrackDrawable = 2130771974;
+			
+			// aapt resource value: 0x7f010171
+			public static int font = 2130772337;
+			
+			// aapt resource value: 0x7f010055
+			public static int fontFamily = 2130772053;
+			
+			// aapt resource value: 0x7f01016a
+			public static int fontProviderAuthority = 2130772330;
+			
+			// aapt resource value: 0x7f01016d
+			public static int fontProviderCerts = 2130772333;
+			
+			// aapt resource value: 0x7f01016e
+			public static int fontProviderFetchStrategy = 2130772334;
+			
+			// aapt resource value: 0x7f01016f
+			public static int fontProviderFetchTimeout = 2130772335;
+			
+			// aapt resource value: 0x7f01016b
+			public static int fontProviderPackage = 2130772331;
+			
+			// aapt resource value: 0x7f01016c
+			public static int fontProviderQuery = 2130772332;
+			
+			// aapt resource value: 0x7f010170
+			public static int fontStyle = 2130772336;
+			
+			// aapt resource value: 0x7f010172
+			public static int fontWeight = 2130772338;
+			
+			// aapt resource value: 0x7f010142
+			public static int foregroundInsidePadding = 2130772290;
+			
+			// aapt resource value: 0x7f0100d2
+			public static int gapBetweenBars = 2130772178;
+			
+			// aapt resource value: 0x7f0100ef
+			public static int goIcon = 2130772207;
+			
+			// aapt resource value: 0x7f010148
+			public static int headerLayout = 2130772296;
+			
+			// aapt resource value: 0x7f010023
+			public static int height = 2130772003;
+			
+			// aapt resource value: 0x7f010037
+			public static int hideOnContentScroll = 2130772023;
+			
+			// aapt resource value: 0x7f010164
+			public static int hintAnimationEnabled = 2130772324;
+			
+			// aapt resource value: 0x7f01015d
+			public static int hintEnabled = 2130772317;
+			
+			// aapt resource value: 0x7f01015c
+			public static int hintTextAppearance = 2130772316;
+			
+			// aapt resource value: 0x7f010085
+			public static int homeAsUpIndicator = 2130772101;
+			
+			// aapt resource value: 0x7f010032
+			public static int homeLayout = 2130772018;
+			
+			// aapt resource value: 0x7f01002b
+			public static int icon = 2130772011;
+			
+			// aapt resource value: 0x7f0100e2
+			public static int iconTint = 2130772194;
+			
+			// aapt resource value: 0x7f0100e3
+			public static int iconTintMode = 2130772195;
+			
+			// aapt resource value: 0x7f0100eb
+			public static int iconifiedByDefault = 2130772203;
+			
+			// aapt resource value: 0x7f010095
+			public static int imageButtonStyle = 2130772117;
+			
+			// aapt resource value: 0x7f010034
+			public static int indeterminateProgressStyle = 2130772020;
+			
+			// aapt resource value: 0x7f010041
+			public static int initialActivityCount = 2130772033;
+			
+			// aapt resource value: 0x7f010149
+			public static int insetForeground = 2130772297;
+			
+			// aapt resource value: 0x7f010024
+			public static int isLightTheme = 2130772004;
+			
+			// aapt resource value: 0x7f010146
+			public static int itemBackground = 2130772294;
+			
+			// aapt resource value: 0x7f010144
+			public static int itemIconTint = 2130772292;
+			
+			// aapt resource value: 0x7f010036
+			public static int itemPadding = 2130772022;
+			
+			// aapt resource value: 0x7f010147
+			public static int itemTextAppearance = 2130772295;
+			
+			// aapt resource value: 0x7f010145
+			public static int itemTextColor = 2130772293;
+			
+			// aapt resource value: 0x7f010131
+			public static int keylines = 2130772273;
+			
+			// aapt resource value: 0x7f0100ea
+			public static int layout = 2130772202;
 			
 			// aapt resource value: 0x7f010000
 			public static int layoutManager = 2130771968;
 			
-			// aapt resource value: 0x7f01010e
-			public static int layout_anchor = 2130772238;
+			// aapt resource value: 0x7f010134
+			public static int layout_anchor = 2130772276;
 			
-			// aapt resource value: 0x7f010110
-			public static int layout_anchorGravity = 2130772240;
+			// aapt resource value: 0x7f010136
+			public static int layout_anchorGravity = 2130772278;
 			
-			// aapt resource value: 0x7f01010d
-			public static int layout_behavior = 2130772237;
+			// aapt resource value: 0x7f010133
+			public static int layout_behavior = 2130772275;
 			
-			// aapt resource value: 0x7f0100fc
-			public static int layout_collapseMode = 2130772220;
+			// aapt resource value: 0x7f01012f
+			public static int layout_collapseMode = 2130772271;
 			
-			// aapt resource value: 0x7f0100fd
-			public static int layout_collapseParallaxMultiplier = 2130772221;
+			// aapt resource value: 0x7f010130
+			public static int layout_collapseParallaxMultiplier = 2130772272;
 			
-			// aapt resource value: 0x7f01010f
-			public static int layout_keyline = 2130772239;
+			// aapt resource value: 0x7f010138
+			public static int layout_dodgeInsetEdges = 2130772280;
 			
-			// aapt resource value: 0x7f0100f8
-			public static int layout_scrollFlags = 2130772216;
+			// aapt resource value: 0x7f010137
+			public static int layout_insetEdge = 2130772279;
 			
-			// aapt resource value: 0x7f0100f9
-			public static int layout_scrollInterpolator = 2130772217;
+			// aapt resource value: 0x7f010135
+			public static int layout_keyline = 2130772277;
+			
+			// aapt resource value: 0x7f01011b
+			public static int layout_scrollFlags = 2130772251;
+			
+			// aapt resource value: 0x7f01011c
+			public static int layout_scrollInterpolator = 2130772252;
+			
+			// aapt resource value: 0x7f0100a7
+			public static int listChoiceBackgroundIndicator = 2130772135;
+			
+			// aapt resource value: 0x7f010081
+			public static int listDividerAlertDialog = 2130772097;
+			
+			// aapt resource value: 0x7f010047
+			public static int listItemLayout = 2130772039;
+			
+			// aapt resource value: 0x7f010044
+			public static int listLayout = 2130772036;
+			
+			// aapt resource value: 0x7f0100c7
+			public static int listMenuViewStyle = 2130772167;
+			
+			// aapt resource value: 0x7f0100a0
+			public static int listPopupWindowStyle = 2130772128;
+			
+			// aapt resource value: 0x7f01009a
+			public static int listPreferredItemHeight = 2130772122;
+			
+			// aapt resource value: 0x7f01009c
+			public static int listPreferredItemHeightLarge = 2130772124;
 			
 			// aapt resource value: 0x7f01009b
-			public static int listChoiceBackgroundIndicator = 2130772123;
+			public static int listPreferredItemHeightSmall = 2130772123;
 			
-			// aapt resource value: 0x7f010076
-			public static int listDividerAlertDialog = 2130772086;
+			// aapt resource value: 0x7f01009d
+			public static int listPreferredItemPaddingLeft = 2130772125;
 			
-			// aapt resource value: 0x7f010049
-			public static int listItemLayout = 2130772041;
+			// aapt resource value: 0x7f01009e
+			public static int listPreferredItemPaddingRight = 2130772126;
 			
-			// aapt resource value: 0x7f010046
-			public static int listLayout = 2130772038;
+			// aapt resource value: 0x7f01002c
+			public static int logo = 2130772012;
 			
-			// aapt resource value: 0x7f010095
-			public static int listPopupWindowStyle = 2130772117;
+			// aapt resource value: 0x7f010110
+			public static int logoDescription = 2130772240;
 			
-			// aapt resource value: 0x7f01008f
-			public static int listPreferredItemHeight = 2130772111;
+			// aapt resource value: 0x7f01014b
+			public static int maxActionInlineWidth = 2130772299;
 			
-			// aapt resource value: 0x7f010091
-			public static int listPreferredItemHeightLarge = 2130772113;
+			// aapt resource value: 0x7f01010a
+			public static int maxButtonHeight = 2130772234;
 			
-			// aapt resource value: 0x7f010090
-			public static int listPreferredItemHeightSmall = 2130772112;
-			
-			// aapt resource value: 0x7f010092
-			public static int listPreferredItemPaddingLeft = 2130772114;
-			
-			// aapt resource value: 0x7f010093
-			public static int listPreferredItemPaddingRight = 2130772115;
-			
-			// aapt resource value: 0x7f010030
-			public static int logo = 2130772016;
-			
-			// aapt resource value: 0x7f0100ef
-			public static int logoDescription = 2130772207;
-			
-			// aapt resource value: 0x7f010122
-			public static int maxActionInlineWidth = 2130772258;
-			
-			// aapt resource value: 0x7f0100ea
-			public static int maxButtonHeight = 2130772202;
-			
-			// aapt resource value: 0x7f0100c5
-			public static int measureWithLargestChild = 2130772165;
-			
-			// aapt resource value: 0x7f010005
-			public static int mediaRouteAudioTrackDrawable = 2130771973;
-			
-			// aapt resource value: 0x7f010006
-			public static int mediaRouteBluetoothIconDrawable = 2130771974;
-			
-			// aapt resource value: 0x7f010007
-			public static int mediaRouteButtonStyle = 2130771975;
-			
-			// aapt resource value: 0x7f010008
-			public static int mediaRouteCastDrawable = 2130771976;
+			// aapt resource value: 0x7f0100d7
+			public static int measureWithLargestChild = 2130772183;
 			
 			// aapt resource value: 0x7f010009
-			public static int mediaRouteChooserPrimaryTextStyle = 2130771977;
+			public static int mediaRouteAudioTrackDrawable = 2130771977;
 			
 			// aapt resource value: 0x7f01000a
-			public static int mediaRouteChooserSecondaryTextStyle = 2130771978;
+			public static int mediaRouteButtonStyle = 2130771978;
+			
+			// aapt resource value: 0x7f010016
+			public static int mediaRouteButtonTint = 2130771990;
 			
 			// aapt resource value: 0x7f01000b
 			public static int mediaRouteCloseDrawable = 2130771979;
 			
 			// aapt resource value: 0x7f01000c
-			public static int mediaRouteCollapseGroupDrawable = 2130771980;
+			public static int mediaRouteControlPanelThemeOverlay = 2130771980;
 			
 			// aapt resource value: 0x7f01000d
-			public static int mediaRouteConnectingDrawable = 2130771981;
+			public static int mediaRouteDefaultIconDrawable = 2130771981;
 			
 			// aapt resource value: 0x7f01000e
-			public static int mediaRouteControllerPrimaryTextStyle = 2130771982;
+			public static int mediaRoutePauseDrawable = 2130771982;
 			
 			// aapt resource value: 0x7f01000f
-			public static int mediaRouteControllerSecondaryTextStyle = 2130771983;
+			public static int mediaRoutePlayDrawable = 2130771983;
 			
 			// aapt resource value: 0x7f010010
-			public static int mediaRouteControllerTitleTextStyle = 2130771984;
+			public static int mediaRouteSpeakerGroupIconDrawable = 2130771984;
 			
 			// aapt resource value: 0x7f010011
-			public static int mediaRouteDefaultIconDrawable = 2130771985;
+			public static int mediaRouteSpeakerIconDrawable = 2130771985;
 			
 			// aapt resource value: 0x7f010012
-			public static int mediaRouteExpandGroupDrawable = 2130771986;
+			public static int mediaRouteStopDrawable = 2130771986;
 			
 			// aapt resource value: 0x7f010013
-			public static int mediaRouteOffDrawable = 2130771987;
+			public static int mediaRouteTheme = 2130771987;
 			
 			// aapt resource value: 0x7f010014
-			public static int mediaRouteOnDrawable = 2130771988;
+			public static int mediaRouteTvIconDrawable = 2130771988;
 			
-			// aapt resource value: 0x7f010015
-			public static int mediaRoutePauseDrawable = 2130771989;
+			// aapt resource value: 0x7f010143
+			public static int menu = 2130772291;
 			
-			// aapt resource value: 0x7f010016
-			public static int mediaRoutePlayDrawable = 2130771990;
+			// aapt resource value: 0x7f010045
+			public static int multiChoiceItemLayout = 2130772037;
 			
-			// aapt resource value: 0x7f010017
-			public static int mediaRouteSpeakerGroupIconDrawable = 2130771991;
+			// aapt resource value: 0x7f01010f
+			public static int navigationContentDescription = 2130772239;
 			
-			// aapt resource value: 0x7f010018
-			public static int mediaRouteSpeakerIconDrawable = 2130771992;
+			// aapt resource value: 0x7f01010e
+			public static int navigationIcon = 2130772238;
 			
-			// aapt resource value: 0x7f010019
-			public static int mediaRouteTvIconDrawable = 2130771993;
+			// aapt resource value: 0x7f010026
+			public static int navigationMode = 2130772006;
 			
-			// aapt resource value: 0x7f01011a
-			public static int menu = 2130772250;
+			// aapt resource value: 0x7f0100db
+			public static int numericModifiers = 2130772187;
 			
-			// aapt resource value: 0x7f010047
-			public static int multiChoiceItemLayout = 2130772039;
+			// aapt resource value: 0x7f0100e6
+			public static int overlapAnchor = 2130772198;
 			
-			// aapt resource value: 0x7f0100ee
-			public static int navigationContentDescription = 2130772206;
+			// aapt resource value: 0x7f0100e8
+			public static int paddingBottomNoButtons = 2130772200;
 			
-			// aapt resource value: 0x7f0100ed
-			public static int navigationIcon = 2130772205;
+			// aapt resource value: 0x7f010114
+			public static int paddingEnd = 2130772244;
 			
-			// aapt resource value: 0x7f01002a
-			public static int navigationMode = 2130772010;
+			// aapt resource value: 0x7f010113
+			public static int paddingStart = 2130772243;
 			
-			// aapt resource value: 0x7f0100cd
-			public static int overlapAnchor = 2130772173;
+			// aapt resource value: 0x7f0100e9
+			public static int paddingTopNoTitle = 2130772201;
 			
-			// aapt resource value: 0x7f0100f3
-			public static int paddingEnd = 2130772211;
+			// aapt resource value: 0x7f0100a4
+			public static int panelBackground = 2130772132;
 			
-			// aapt resource value: 0x7f0100f2
-			public static int paddingStart = 2130772210;
+			// aapt resource value: 0x7f0100a6
+			public static int panelMenuListTheme = 2130772134;
 			
-			// aapt resource value: 0x7f010098
-			public static int panelBackground = 2130772120;
+			// aapt resource value: 0x7f0100a5
+			public static int panelMenuListWidth = 2130772133;
 			
-			// aapt resource value: 0x7f01009a
-			public static int panelMenuListTheme = 2130772122;
+			// aapt resource value: 0x7f010167
+			public static int passwordToggleContentDescription = 2130772327;
 			
-			// aapt resource value: 0x7f010099
-			public static int panelMenuListWidth = 2130772121;
+			// aapt resource value: 0x7f010166
+			public static int passwordToggleDrawable = 2130772326;
 			
-			// aapt resource value: 0x7f010086
-			public static int popupMenuStyle = 2130772102;
+			// aapt resource value: 0x7f010165
+			public static int passwordToggleEnabled = 2130772325;
 			
-			// aapt resource value: 0x7f010041
-			public static int popupTheme = 2130772033;
+			// aapt resource value: 0x7f010168
+			public static int passwordToggleTint = 2130772328;
 			
-			// aapt resource value: 0x7f010087
-			public static int popupWindowStyle = 2130772103;
+			// aapt resource value: 0x7f010169
+			public static int passwordToggleTintMode = 2130772329;
 			
-			// aapt resource value: 0x7f0100cc
-			public static int preserveIconSpacing = 2130772172;
+			// aapt resource value: 0x7f010091
+			public static int popupMenuStyle = 2130772113;
 			
-			// aapt resource value: 0x7f010116
-			public static int pressedTranslationZ = 2130772246;
+			// aapt resource value: 0x7f01003f
+			public static int popupTheme = 2130772031;
 			
-			// aapt resource value: 0x7f010039
-			public static int progressBarPadding = 2130772025;
+			// aapt resource value: 0x7f010092
+			public static int popupWindowStyle = 2130772114;
 			
-			// aapt resource value: 0x7f010037
-			public static int progressBarStyle = 2130772023;
+			// aapt resource value: 0x7f0100e4
+			public static int preserveIconSpacing = 2130772196;
 			
-			// aapt resource value: 0x7f0100da
-			public static int queryBackground = 2130772186;
+			// aapt resource value: 0x7f01013e
+			public static int pressedTranslationZ = 2130772286;
 			
-			// aapt resource value: 0x7f0100d1
-			public static int queryHint = 2130772177;
+			// aapt resource value: 0x7f010035
+			public static int progressBarPadding = 2130772021;
 			
-			// aapt resource value: 0x7f0100b3
-			public static int radioButtonStyle = 2130772147;
+			// aapt resource value: 0x7f010033
+			public static int progressBarStyle = 2130772019;
 			
-			// aapt resource value: 0x7f0100b4
-			public static int ratingBarStyle = 2130772148;
+			// aapt resource value: 0x7f0100f5
+			public static int queryBackground = 2130772213;
 			
-			// aapt resource value: 0x7f0100b5
-			public static int ratingBarStyleIndicator = 2130772149;
+			// aapt resource value: 0x7f0100ec
+			public static int queryHint = 2130772204;
 			
-			// aapt resource value: 0x7f0100b6
-			public static int ratingBarStyleSmall = 2130772150;
+			// aapt resource value: 0x7f0100c0
+			public static int radioButtonStyle = 2130772160;
+			
+			// aapt resource value: 0x7f0100c1
+			public static int ratingBarStyle = 2130772161;
+			
+			// aapt resource value: 0x7f0100c2
+			public static int ratingBarStyleIndicator = 2130772162;
+			
+			// aapt resource value: 0x7f0100c3
+			public static int ratingBarStyleSmall = 2130772163;
 			
 			// aapt resource value: 0x7f010002
 			public static int reverseLayout = 2130771970;
 			
-			// aapt resource value: 0x7f010114
-			public static int rippleColor = 2130772244;
+			// aapt resource value: 0x7f01013c
+			public static int rippleColor = 2130772284;
 			
-			// aapt resource value: 0x7f0100d6
-			public static int searchHintIcon = 2130772182;
+			// aapt resource value: 0x7f01012b
+			public static int scrimAnimationDuration = 2130772267;
 			
-			// aapt resource value: 0x7f0100d5
-			public static int searchIcon = 2130772181;
+			// aapt resource value: 0x7f01012a
+			public static int scrimVisibleHeightTrigger = 2130772266;
 			
-			// aapt resource value: 0x7f01008e
-			public static int searchViewStyle = 2130772110;
+			// aapt resource value: 0x7f0100f1
+			public static int searchHintIcon = 2130772209;
 			
-			// aapt resource value: 0x7f0100b7
-			public static int seekBarStyle = 2130772151;
+			// aapt resource value: 0x7f0100f0
+			public static int searchIcon = 2130772208;
 			
-			// aapt resource value: 0x7f01007e
-			public static int selectableItemBackground = 2130772094;
+			// aapt resource value: 0x7f010099
+			public static int searchViewStyle = 2130772121;
 			
-			// aapt resource value: 0x7f01007f
-			public static int selectableItemBackgroundBorderless = 2130772095;
+			// aapt resource value: 0x7f0100c4
+			public static int seekBarStyle = 2130772164;
 			
-			// aapt resource value: 0x7f0100c8
-			public static int showAsAction = 2130772168;
+			// aapt resource value: 0x7f010089
+			public static int selectableItemBackground = 2130772105;
 			
-			// aapt resource value: 0x7f0100c6
-			public static int showDividers = 2130772166;
+			// aapt resource value: 0x7f01008a
+			public static int selectableItemBackgroundBorderless = 2130772106;
 			
-			// aapt resource value: 0x7f0100e2
-			public static int showText = 2130772194;
+			// aapt resource value: 0x7f0100dc
+			public static int showAsAction = 2130772188;
+			
+			// aapt resource value: 0x7f0100d8
+			public static int showDividers = 2130772184;
+			
+			// aapt resource value: 0x7f010101
+			public static int showText = 2130772225;
 			
 			// aapt resource value: 0x7f010048
-			public static int singleChoiceItemLayout = 2130772040;
+			public static int showTitle = 2130772040;
+			
+			// aapt resource value: 0x7f010046
+			public static int singleChoiceItemLayout = 2130772038;
 			
 			// aapt resource value: 0x7f010001
 			public static int spanCount = 2130771969;
 			
-			// aapt resource value: 0x7f0100be
-			public static int spinBars = 2130772158;
+			// aapt resource value: 0x7f0100d0
+			public static int spinBars = 2130772176;
 			
-			// aapt resource value: 0x7f010079
-			public static int spinnerDropDownItemStyle = 2130772089;
+			// aapt resource value: 0x7f010084
+			public static int spinnerDropDownItemStyle = 2130772100;
 			
-			// aapt resource value: 0x7f0100b8
-			public static int spinnerStyle = 2130772152;
+			// aapt resource value: 0x7f0100c5
+			public static int spinnerStyle = 2130772165;
 			
-			// aapt resource value: 0x7f0100e1
-			public static int splitTrack = 2130772193;
+			// aapt resource value: 0x7f010100
+			public static int splitTrack = 2130772224;
 			
-			// aapt resource value: 0x7f01004a
-			public static int srcCompat = 2130772042;
+			// aapt resource value: 0x7f010049
+			public static int srcCompat = 2130772041;
 			
 			// aapt resource value: 0x7f010003
 			public static int stackFromEnd = 2130771971;
 			
-			// aapt resource value: 0x7f0100ce
-			public static int state_above_anchor = 2130772174;
+			// aapt resource value: 0x7f0100e7
+			public static int state_above_anchor = 2130772199;
 			
-			// aapt resource value: 0x7f01010c
-			public static int statusBarBackground = 2130772236;
+			// aapt resource value: 0x7f010119
+			public static int state_collapsed = 2130772249;
 			
-			// aapt resource value: 0x7f010106
-			public static int statusBarScrim = 2130772230;
-			
-			// aapt resource value: 0x7f0100db
-			public static int submitBackground = 2130772187;
-			
-			// aapt resource value: 0x7f01002c
-			public static int subtitle = 2130772012;
-			
-			// aapt resource value: 0x7f0100e4
-			public static int subtitleTextAppearance = 2130772196;
-			
-			// aapt resource value: 0x7f0100f1
-			public static int subtitleTextColor = 2130772209;
-			
-			// aapt resource value: 0x7f01002e
-			public static int subtitleTextStyle = 2130772014;
-			
-			// aapt resource value: 0x7f0100d9
-			public static int suggestionRowLayout = 2130772185;
-			
-			// aapt resource value: 0x7f0100df
-			public static int switchMinWidth = 2130772191;
-			
-			// aapt resource value: 0x7f0100e0
-			public static int switchPadding = 2130772192;
-			
-			// aapt resource value: 0x7f0100b9
-			public static int switchStyle = 2130772153;
-			
-			// aapt resource value: 0x7f0100de
-			public static int switchTextAppearance = 2130772190;
-			
-			// aapt resource value: 0x7f010126
-			public static int tabBackground = 2130772262;
-			
-			// aapt resource value: 0x7f010125
-			public static int tabContentStart = 2130772261;
-			
-			// aapt resource value: 0x7f010128
-			public static int tabGravity = 2130772264;
-			
-			// aapt resource value: 0x7f010123
-			public static int tabIndicatorColor = 2130772259;
-			
-			// aapt resource value: 0x7f010124
-			public static int tabIndicatorHeight = 2130772260;
-			
-			// aapt resource value: 0x7f01012a
-			public static int tabMaxWidth = 2130772266;
-			
-			// aapt resource value: 0x7f010129
-			public static int tabMinWidth = 2130772265;
-			
-			// aapt resource value: 0x7f010127
-			public static int tabMode = 2130772263;
+			// aapt resource value: 0x7f01011a
+			public static int state_collapsible = 2130772250;
 			
 			// aapt resource value: 0x7f010132
-			public static int tabPadding = 2130772274;
+			public static int statusBarBackground = 2130772274;
 			
-			// aapt resource value: 0x7f010131
-			public static int tabPaddingBottom = 2130772273;
-			
-			// aapt resource value: 0x7f010130
-			public static int tabPaddingEnd = 2130772272;
-			
-			// aapt resource value: 0x7f01012e
-			public static int tabPaddingStart = 2130772270;
-			
-			// aapt resource value: 0x7f01012f
-			public static int tabPaddingTop = 2130772271;
-			
-			// aapt resource value: 0x7f01012d
-			public static int tabSelectedTextColor = 2130772269;
-			
-			// aapt resource value: 0x7f01012b
-			public static int tabTextAppearance = 2130772267;
-			
-			// aapt resource value: 0x7f01012c
-			public static int tabTextColor = 2130772268;
-			
-			// aapt resource value: 0x7f01004b
-			public static int textAllCaps = 2130772043;
-			
-			// aapt resource value: 0x7f010072
-			public static int textAppearanceLargePopupMenu = 2130772082;
-			
-			// aapt resource value: 0x7f010096
-			public static int textAppearanceListItem = 2130772118;
-			
-			// aapt resource value: 0x7f010097
-			public static int textAppearanceListItemSmall = 2130772119;
-			
-			// aapt resource value: 0x7f01008c
-			public static int textAppearanceSearchResultSubtitle = 2130772108;
-			
-			// aapt resource value: 0x7f01008b
-			public static int textAppearanceSearchResultTitle = 2130772107;
-			
-			// aapt resource value: 0x7f010073
-			public static int textAppearanceSmallPopupMenu = 2130772083;
-			
-			// aapt resource value: 0x7f0100a9
-			public static int textColorAlertDialogListItem = 2130772137;
-			
-			// aapt resource value: 0x7f010113
-			public static int textColorError = 2130772243;
-			
-			// aapt resource value: 0x7f01008d
-			public static int textColorSearchUrl = 2130772109;
-			
-			// aapt resource value: 0x7f0100f4
-			public static int theme = 2130772212;
-			
-			// aapt resource value: 0x7f0100c4
-			public static int thickness = 2130772164;
-			
-			// aapt resource value: 0x7f0100dd
-			public static int thumbTextPadding = 2130772189;
-			
-			// aapt resource value: 0x7f010029
-			public static int title = 2130772009;
-			
-			// aapt resource value: 0x7f01010a
-			public static int titleEnabled = 2130772234;
-			
-			// aapt resource value: 0x7f0100e9
-			public static int titleMarginBottom = 2130772201;
-			
-			// aapt resource value: 0x7f0100e7
-			public static int titleMarginEnd = 2130772199;
-			
-			// aapt resource value: 0x7f0100e6
-			public static int titleMarginStart = 2130772198;
-			
-			// aapt resource value: 0x7f0100e8
-			public static int titleMarginTop = 2130772200;
+			// aapt resource value: 0x7f010128
+			public static int statusBarScrim = 2130772264;
 			
 			// aapt resource value: 0x7f0100e5
-			public static int titleMargins = 2130772197;
+			public static int subMenuArrow = 2130772197;
 			
-			// aapt resource value: 0x7f0100e3
-			public static int titleTextAppearance = 2130772195;
+			// aapt resource value: 0x7f0100f6
+			public static int submitBackground = 2130772214;
 			
-			// aapt resource value: 0x7f0100f0
-			public static int titleTextColor = 2130772208;
+			// aapt resource value: 0x7f010028
+			public static int subtitle = 2130772008;
 			
-			// aapt resource value: 0x7f01002d
-			public static int titleTextStyle = 2130772013;
+			// aapt resource value: 0x7f010103
+			public static int subtitleTextAppearance = 2130772227;
 			
-			// aapt resource value: 0x7f010107
-			public static int toolbarId = 2130772231;
+			// aapt resource value: 0x7f010112
+			public static int subtitleTextColor = 2130772242;
 			
-			// aapt resource value: 0x7f010085
-			public static int toolbarNavigationButtonStyle = 2130772101;
+			// aapt resource value: 0x7f01002a
+			public static int subtitleTextStyle = 2130772010;
 			
-			// aapt resource value: 0x7f010084
-			public static int toolbarStyle = 2130772100;
+			// aapt resource value: 0x7f0100f4
+			public static int suggestionRowLayout = 2130772212;
 			
-			// aapt resource value: 0x7f0100dc
-			public static int track = 2130772188;
+			// aapt resource value: 0x7f0100fe
+			public static int switchMinWidth = 2130772222;
 			
-			// aapt resource value: 0x7f010118
-			public static int useCompatPadding = 2130772248;
+			// aapt resource value: 0x7f0100ff
+			public static int switchPadding = 2130772223;
 			
-			// aapt resource value: 0x7f0100d7
-			public static int voiceIcon = 2130772183;
+			// aapt resource value: 0x7f0100c6
+			public static int switchStyle = 2130772166;
 			
-			// aapt resource value: 0x7f01004c
-			public static int windowActionBar = 2130772044;
+			// aapt resource value: 0x7f0100fd
+			public static int switchTextAppearance = 2130772221;
 			
-			// aapt resource value: 0x7f01004e
-			public static int windowActionBarOverlay = 2130772046;
+			// aapt resource value: 0x7f01014f
+			public static int tabBackground = 2130772303;
+			
+			// aapt resource value: 0x7f01014e
+			public static int tabContentStart = 2130772302;
+			
+			// aapt resource value: 0x7f010151
+			public static int tabGravity = 2130772305;
+			
+			// aapt resource value: 0x7f01014c
+			public static int tabIndicatorColor = 2130772300;
+			
+			// aapt resource value: 0x7f01014d
+			public static int tabIndicatorHeight = 2130772301;
+			
+			// aapt resource value: 0x7f010153
+			public static int tabMaxWidth = 2130772307;
+			
+			// aapt resource value: 0x7f010152
+			public static int tabMinWidth = 2130772306;
+			
+			// aapt resource value: 0x7f010150
+			public static int tabMode = 2130772304;
+			
+			// aapt resource value: 0x7f01015b
+			public static int tabPadding = 2130772315;
+			
+			// aapt resource value: 0x7f01015a
+			public static int tabPaddingBottom = 2130772314;
+			
+			// aapt resource value: 0x7f010159
+			public static int tabPaddingEnd = 2130772313;
+			
+			// aapt resource value: 0x7f010157
+			public static int tabPaddingStart = 2130772311;
+			
+			// aapt resource value: 0x7f010158
+			public static int tabPaddingTop = 2130772312;
+			
+			// aapt resource value: 0x7f010156
+			public static int tabSelectedTextColor = 2130772310;
+			
+			// aapt resource value: 0x7f010154
+			public static int tabTextAppearance = 2130772308;
+			
+			// aapt resource value: 0x7f010155
+			public static int tabTextColor = 2130772309;
 			
 			// aapt resource value: 0x7f01004f
-			public static int windowActionModeOverlay = 2130772047;
+			public static int textAllCaps = 2130772047;
 			
-			// aapt resource value: 0x7f010053
-			public static int windowFixedHeightMajor = 2130772051;
+			// aapt resource value: 0x7f01007c
+			public static int textAppearanceLargePopupMenu = 2130772092;
 			
-			// aapt resource value: 0x7f010051
-			public static int windowFixedHeightMinor = 2130772049;
+			// aapt resource value: 0x7f0100a1
+			public static int textAppearanceListItem = 2130772129;
 			
-			// aapt resource value: 0x7f010050
-			public static int windowFixedWidthMajor = 2130772048;
+			// aapt resource value: 0x7f0100a2
+			public static int textAppearanceListItemSecondary = 2130772130;
 			
-			// aapt resource value: 0x7f010052
-			public static int windowFixedWidthMinor = 2130772050;
+			// aapt resource value: 0x7f0100a3
+			public static int textAppearanceListItemSmall = 2130772131;
 			
-			// aapt resource value: 0x7f010054
-			public static int windowMinWidthMajor = 2130772052;
+			// aapt resource value: 0x7f01007e
+			public static int textAppearancePopupMenuHeader = 2130772094;
 			
-			// aapt resource value: 0x7f010055
-			public static int windowMinWidthMinor = 2130772053;
+			// aapt resource value: 0x7f010097
+			public static int textAppearanceSearchResultSubtitle = 2130772119;
+			
+			// aapt resource value: 0x7f010096
+			public static int textAppearanceSearchResultTitle = 2130772118;
+			
+			// aapt resource value: 0x7f01007d
+			public static int textAppearanceSmallPopupMenu = 2130772093;
+			
+			// aapt resource value: 0x7f0100b6
+			public static int textColorAlertDialogListItem = 2130772150;
+			
+			// aapt resource value: 0x7f01013b
+			public static int textColorError = 2130772283;
+			
+			// aapt resource value: 0x7f010098
+			public static int textColorSearchUrl = 2130772120;
+			
+			// aapt resource value: 0x7f010115
+			public static int theme = 2130772245;
+			
+			// aapt resource value: 0x7f0100d6
+			public static int thickness = 2130772182;
+			
+			// aapt resource value: 0x7f0100fc
+			public static int thumbTextPadding = 2130772220;
+			
+			// aapt resource value: 0x7f0100f7
+			public static int thumbTint = 2130772215;
+			
+			// aapt resource value: 0x7f0100f8
+			public static int thumbTintMode = 2130772216;
+			
+			// aapt resource value: 0x7f01004c
+			public static int tickMark = 2130772044;
 			
 			// aapt resource value: 0x7f01004d
-			public static int windowNoTitle = 2130772045;
+			public static int tickMarkTint = 2130772045;
+			
+			// aapt resource value: 0x7f01004e
+			public static int tickMarkTintMode = 2130772046;
+			
+			// aapt resource value: 0x7f01004a
+			public static int tint = 2130772042;
+			
+			// aapt resource value: 0x7f01004b
+			public static int tintMode = 2130772043;
+			
+			// aapt resource value: 0x7f010025
+			public static int title = 2130772005;
+			
+			// aapt resource value: 0x7f01012e
+			public static int titleEnabled = 2130772270;
+			
+			// aapt resource value: 0x7f010104
+			public static int titleMargin = 2130772228;
+			
+			// aapt resource value: 0x7f010108
+			public static int titleMarginBottom = 2130772232;
+			
+			// aapt resource value: 0x7f010106
+			public static int titleMarginEnd = 2130772230;
+			
+			// aapt resource value: 0x7f010105
+			public static int titleMarginStart = 2130772229;
+			
+			// aapt resource value: 0x7f010107
+			public static int titleMarginTop = 2130772231;
+			
+			// aapt resource value: 0x7f010109
+			public static int titleMargins = 2130772233;
+			
+			// aapt resource value: 0x7f010102
+			public static int titleTextAppearance = 2130772226;
+			
+			// aapt resource value: 0x7f010111
+			public static int titleTextColor = 2130772241;
+			
+			// aapt resource value: 0x7f010029
+			public static int titleTextStyle = 2130772009;
+			
+			// aapt resource value: 0x7f010129
+			public static int toolbarId = 2130772265;
+			
+			// aapt resource value: 0x7f010090
+			public static int toolbarNavigationButtonStyle = 2130772112;
+			
+			// aapt resource value: 0x7f01008f
+			public static int toolbarStyle = 2130772111;
+			
+			// aapt resource value: 0x7f0100c9
+			public static int tooltipForegroundColor = 2130772169;
+			
+			// aapt resource value: 0x7f0100c8
+			public static int tooltipFrameBackground = 2130772168;
+			
+			// aapt resource value: 0x7f0100e1
+			public static int tooltipText = 2130772193;
+			
+			// aapt resource value: 0x7f0100f9
+			public static int track = 2130772217;
+			
+			// aapt resource value: 0x7f0100fa
+			public static int trackTint = 2130772218;
+			
+			// aapt resource value: 0x7f0100fb
+			public static int trackTintMode = 2130772219;
+			
+			// aapt resource value: 0x7f010140
+			public static int useCompatPadding = 2130772288;
+			
+			// aapt resource value: 0x7f0100f2
+			public static int voiceIcon = 2130772210;
+			
+			// aapt resource value: 0x7f010056
+			public static int windowActionBar = 2130772054;
+			
+			// aapt resource value: 0x7f010058
+			public static int windowActionBarOverlay = 2130772056;
+			
+			// aapt resource value: 0x7f010059
+			public static int windowActionModeOverlay = 2130772057;
+			
+			// aapt resource value: 0x7f01005d
+			public static int windowFixedHeightMajor = 2130772061;
+			
+			// aapt resource value: 0x7f01005b
+			public static int windowFixedHeightMinor = 2130772059;
+			
+			// aapt resource value: 0x7f01005a
+			public static int windowFixedWidthMajor = 2130772058;
+			
+			// aapt resource value: 0x7f01005c
+			public static int windowFixedWidthMinor = 2130772060;
+			
+			// aapt resource value: 0x7f01005e
+			public static int windowMinWidthMajor = 2130772062;
+			
+			// aapt resource value: 0x7f01005f
+			public static int windowMinWidthMinor = 2130772063;
+			
+			// aapt resource value: 0x7f010057
+			public static int windowNoTitle = 2130772055;
 			
 			static Attribute()
 			{
@@ -1049,29 +1230,20 @@ namespace SuaveControls.MaterialForms.Android
 		public partial class Boolean
 		{
 			
-			// aapt resource value: 0x7f0c0003
-			public static int abc_action_bar_embed_tabs = 2131492867;
+			// aapt resource value: 0x7f0d0000
+			public static int abc_action_bar_embed_tabs = 2131558400;
 			
-			// aapt resource value: 0x7f0c0001
-			public static int abc_action_bar_embed_tabs_pre_jb = 2131492865;
+			// aapt resource value: 0x7f0d0001
+			public static int abc_allow_stacked_button_bar = 2131558401;
 			
-			// aapt resource value: 0x7f0c0004
-			public static int abc_action_bar_expanded_action_views_exclusive = 2131492868;
+			// aapt resource value: 0x7f0d0002
+			public static int abc_config_actionMenuItemAllCaps = 2131558402;
 			
-			// aapt resource value: 0x7f0c0000
-			public static int abc_allow_stacked_button_bar = 2131492864;
+			// aapt resource value: 0x7f0d0003
+			public static int abc_config_closeDialogWhenTouchOutside = 2131558403;
 			
-			// aapt resource value: 0x7f0c0005
-			public static int abc_config_actionMenuItemAllCaps = 2131492869;
-			
-			// aapt resource value: 0x7f0c0002
-			public static int abc_config_allowActionMenuItemTextWithIcon = 2131492866;
-			
-			// aapt resource value: 0x7f0c0006
-			public static int abc_config_closeDialogWhenTouchOutside = 2131492870;
-			
-			// aapt resource value: 0x7f0c0007
-			public static int abc_config_showMenuShortcutsWhenKeyboardPresent = 2131492871;
+			// aapt resource value: 0x7f0d0004
+			public static int abc_config_showMenuShortcutsWhenKeyboardPresent = 2131558404;
 			
 			static Boolean()
 			{
@@ -1086,257 +1258,302 @@ namespace SuaveControls.MaterialForms.Android
 		public partial class Color
 		{
 			
-			// aapt resource value: 0x7f0b0048
-			public static int abc_background_cache_hint_selector_material_dark = 2131427400;
+			// aapt resource value: 0x7f0c004b
+			public static int abc_background_cache_hint_selector_material_dark = 2131492939;
 			
-			// aapt resource value: 0x7f0b0049
-			public static int abc_background_cache_hint_selector_material_light = 2131427401;
+			// aapt resource value: 0x7f0c004c
+			public static int abc_background_cache_hint_selector_material_light = 2131492940;
 			
-			// aapt resource value: 0x7f0b004a
-			public static int abc_color_highlight_material = 2131427402;
+			// aapt resource value: 0x7f0c004d
+			public static int abc_btn_colored_borderless_text_material = 2131492941;
 			
-			// aapt resource value: 0x7f0b0004
-			public static int abc_input_method_navigation_guard = 2131427332;
+			// aapt resource value: 0x7f0c004e
+			public static int abc_btn_colored_text_material = 2131492942;
 			
-			// aapt resource value: 0x7f0b004b
-			public static int abc_primary_text_disable_only_material_dark = 2131427403;
+			// aapt resource value: 0x7f0c004f
+			public static int abc_color_highlight_material = 2131492943;
 			
-			// aapt resource value: 0x7f0b004c
-			public static int abc_primary_text_disable_only_material_light = 2131427404;
+			// aapt resource value: 0x7f0c0050
+			public static int abc_hint_foreground_material_dark = 2131492944;
 			
-			// aapt resource value: 0x7f0b004d
-			public static int abc_primary_text_material_dark = 2131427405;
+			// aapt resource value: 0x7f0c0051
+			public static int abc_hint_foreground_material_light = 2131492945;
 			
-			// aapt resource value: 0x7f0b004e
-			public static int abc_primary_text_material_light = 2131427406;
+			// aapt resource value: 0x7f0c0004
+			public static int abc_input_method_navigation_guard = 2131492868;
 			
-			// aapt resource value: 0x7f0b004f
-			public static int abc_search_url_text = 2131427407;
+			// aapt resource value: 0x7f0c0052
+			public static int abc_primary_text_disable_only_material_dark = 2131492946;
 			
-			// aapt resource value: 0x7f0b0005
-			public static int abc_search_url_text_normal = 2131427333;
+			// aapt resource value: 0x7f0c0053
+			public static int abc_primary_text_disable_only_material_light = 2131492947;
 			
-			// aapt resource value: 0x7f0b0006
-			public static int abc_search_url_text_pressed = 2131427334;
+			// aapt resource value: 0x7f0c0054
+			public static int abc_primary_text_material_dark = 2131492948;
 			
-			// aapt resource value: 0x7f0b0007
-			public static int abc_search_url_text_selected = 2131427335;
+			// aapt resource value: 0x7f0c0055
+			public static int abc_primary_text_material_light = 2131492949;
 			
-			// aapt resource value: 0x7f0b0050
-			public static int abc_secondary_text_material_dark = 2131427408;
+			// aapt resource value: 0x7f0c0056
+			public static int abc_search_url_text = 2131492950;
 			
-			// aapt resource value: 0x7f0b0051
-			public static int abc_secondary_text_material_light = 2131427409;
+			// aapt resource value: 0x7f0c0005
+			public static int abc_search_url_text_normal = 2131492869;
 			
-			// aapt resource value: 0x7f0b0008
-			public static int accent_material_dark = 2131427336;
+			// aapt resource value: 0x7f0c0006
+			public static int abc_search_url_text_pressed = 2131492870;
 			
-			// aapt resource value: 0x7f0b0009
-			public static int accent_material_light = 2131427337;
+			// aapt resource value: 0x7f0c0007
+			public static int abc_search_url_text_selected = 2131492871;
 			
-			// aapt resource value: 0x7f0b000a
-			public static int background_floating_material_dark = 2131427338;
+			// aapt resource value: 0x7f0c0057
+			public static int abc_secondary_text_material_dark = 2131492951;
 			
-			// aapt resource value: 0x7f0b000b
-			public static int background_floating_material_light = 2131427339;
+			// aapt resource value: 0x7f0c0058
+			public static int abc_secondary_text_material_light = 2131492952;
 			
-			// aapt resource value: 0x7f0b000c
-			public static int background_material_dark = 2131427340;
+			// aapt resource value: 0x7f0c0059
+			public static int abc_tint_btn_checkable = 2131492953;
 			
-			// aapt resource value: 0x7f0b000d
-			public static int background_material_light = 2131427341;
+			// aapt resource value: 0x7f0c005a
+			public static int abc_tint_default = 2131492954;
 			
-			// aapt resource value: 0x7f0b000e
-			public static int bright_foreground_disabled_material_dark = 2131427342;
+			// aapt resource value: 0x7f0c005b
+			public static int abc_tint_edittext = 2131492955;
 			
-			// aapt resource value: 0x7f0b000f
-			public static int bright_foreground_disabled_material_light = 2131427343;
+			// aapt resource value: 0x7f0c005c
+			public static int abc_tint_seek_thumb = 2131492956;
 			
-			// aapt resource value: 0x7f0b0010
-			public static int bright_foreground_inverse_material_dark = 2131427344;
+			// aapt resource value: 0x7f0c005d
+			public static int abc_tint_spinner = 2131492957;
 			
-			// aapt resource value: 0x7f0b0011
-			public static int bright_foreground_inverse_material_light = 2131427345;
+			// aapt resource value: 0x7f0c005e
+			public static int abc_tint_switch_track = 2131492958;
 			
-			// aapt resource value: 0x7f0b0012
-			public static int bright_foreground_material_dark = 2131427346;
+			// aapt resource value: 0x7f0c0008
+			public static int accent_material_dark = 2131492872;
 			
-			// aapt resource value: 0x7f0b0013
-			public static int bright_foreground_material_light = 2131427347;
+			// aapt resource value: 0x7f0c0009
+			public static int accent_material_light = 2131492873;
 			
-			// aapt resource value: 0x7f0b0014
-			public static int button_material_dark = 2131427348;
+			// aapt resource value: 0x7f0c000a
+			public static int background_floating_material_dark = 2131492874;
 			
-			// aapt resource value: 0x7f0b0015
-			public static int button_material_light = 2131427349;
+			// aapt resource value: 0x7f0c000b
+			public static int background_floating_material_light = 2131492875;
 			
-			// aapt resource value: 0x7f0b0000
-			public static int cardview_dark_background = 2131427328;
+			// aapt resource value: 0x7f0c000c
+			public static int background_material_dark = 2131492876;
 			
-			// aapt resource value: 0x7f0b0001
-			public static int cardview_light_background = 2131427329;
+			// aapt resource value: 0x7f0c000d
+			public static int background_material_light = 2131492877;
 			
-			// aapt resource value: 0x7f0b0002
-			public static int cardview_shadow_end_color = 2131427330;
+			// aapt resource value: 0x7f0c000e
+			public static int bright_foreground_disabled_material_dark = 2131492878;
 			
-			// aapt resource value: 0x7f0b0003
-			public static int cardview_shadow_start_color = 2131427331;
+			// aapt resource value: 0x7f0c000f
+			public static int bright_foreground_disabled_material_light = 2131492879;
 			
-			// aapt resource value: 0x7f0b003e
-			public static int design_fab_shadow_end_color = 2131427390;
+			// aapt resource value: 0x7f0c0010
+			public static int bright_foreground_inverse_material_dark = 2131492880;
 			
-			// aapt resource value: 0x7f0b003f
-			public static int design_fab_shadow_mid_color = 2131427391;
+			// aapt resource value: 0x7f0c0011
+			public static int bright_foreground_inverse_material_light = 2131492881;
 			
-			// aapt resource value: 0x7f0b0040
-			public static int design_fab_shadow_start_color = 2131427392;
+			// aapt resource value: 0x7f0c0012
+			public static int bright_foreground_material_dark = 2131492882;
 			
-			// aapt resource value: 0x7f0b0041
-			public static int design_fab_stroke_end_inner_color = 2131427393;
+			// aapt resource value: 0x7f0c0013
+			public static int bright_foreground_material_light = 2131492883;
 			
-			// aapt resource value: 0x7f0b0042
-			public static int design_fab_stroke_end_outer_color = 2131427394;
+			// aapt resource value: 0x7f0c0014
+			public static int button_material_dark = 2131492884;
 			
-			// aapt resource value: 0x7f0b0043
-			public static int design_fab_stroke_top_inner_color = 2131427395;
+			// aapt resource value: 0x7f0c0015
+			public static int button_material_light = 2131492885;
 			
-			// aapt resource value: 0x7f0b0044
-			public static int design_fab_stroke_top_outer_color = 2131427396;
+			// aapt resource value: 0x7f0c0000
+			public static int cardview_dark_background = 2131492864;
 			
-			// aapt resource value: 0x7f0b0045
-			public static int design_snackbar_background_color = 2131427397;
+			// aapt resource value: 0x7f0c0001
+			public static int cardview_light_background = 2131492865;
 			
-			// aapt resource value: 0x7f0b0046
-			public static int design_textinput_error_color_dark = 2131427398;
+			// aapt resource value: 0x7f0c0002
+			public static int cardview_shadow_end_color = 2131492866;
 			
-			// aapt resource value: 0x7f0b0047
-			public static int design_textinput_error_color_light = 2131427399;
+			// aapt resource value: 0x7f0c0003
+			public static int cardview_shadow_start_color = 2131492867;
 			
-			// aapt resource value: 0x7f0b0016
-			public static int dim_foreground_disabled_material_dark = 2131427350;
+			// aapt resource value: 0x7f0c0040
+			public static int design_bottom_navigation_shadow_color = 2131492928;
 			
-			// aapt resource value: 0x7f0b0017
-			public static int dim_foreground_disabled_material_light = 2131427351;
+			// aapt resource value: 0x7f0c005f
+			public static int design_error = 2131492959;
 			
-			// aapt resource value: 0x7f0b0018
-			public static int dim_foreground_material_dark = 2131427352;
+			// aapt resource value: 0x7f0c0041
+			public static int design_fab_shadow_end_color = 2131492929;
 			
-			// aapt resource value: 0x7f0b0019
-			public static int dim_foreground_material_light = 2131427353;
+			// aapt resource value: 0x7f0c0042
+			public static int design_fab_shadow_mid_color = 2131492930;
 			
-			// aapt resource value: 0x7f0b001a
-			public static int foreground_material_dark = 2131427354;
+			// aapt resource value: 0x7f0c0043
+			public static int design_fab_shadow_start_color = 2131492931;
 			
-			// aapt resource value: 0x7f0b001b
-			public static int foreground_material_light = 2131427355;
+			// aapt resource value: 0x7f0c0044
+			public static int design_fab_stroke_end_inner_color = 2131492932;
 			
-			// aapt resource value: 0x7f0b001c
-			public static int highlighted_text_material_dark = 2131427356;
+			// aapt resource value: 0x7f0c0045
+			public static int design_fab_stroke_end_outer_color = 2131492933;
 			
-			// aapt resource value: 0x7f0b001d
-			public static int highlighted_text_material_light = 2131427357;
+			// aapt resource value: 0x7f0c0046
+			public static int design_fab_stroke_top_inner_color = 2131492934;
 			
-			// aapt resource value: 0x7f0b001e
-			public static int hint_foreground_material_dark = 2131427358;
+			// aapt resource value: 0x7f0c0047
+			public static int design_fab_stroke_top_outer_color = 2131492935;
 			
-			// aapt resource value: 0x7f0b001f
-			public static int hint_foreground_material_light = 2131427359;
+			// aapt resource value: 0x7f0c0048
+			public static int design_snackbar_background_color = 2131492936;
 			
-			// aapt resource value: 0x7f0b0020
-			public static int material_blue_grey_800 = 2131427360;
+			// aapt resource value: 0x7f0c0060
+			public static int design_tint_password_toggle = 2131492960;
 			
-			// aapt resource value: 0x7f0b0021
-			public static int material_blue_grey_900 = 2131427361;
+			// aapt resource value: 0x7f0c0016
+			public static int dim_foreground_disabled_material_dark = 2131492886;
 			
-			// aapt resource value: 0x7f0b0022
-			public static int material_blue_grey_950 = 2131427362;
+			// aapt resource value: 0x7f0c0017
+			public static int dim_foreground_disabled_material_light = 2131492887;
 			
-			// aapt resource value: 0x7f0b0023
-			public static int material_deep_teal_200 = 2131427363;
+			// aapt resource value: 0x7f0c0018
+			public static int dim_foreground_material_dark = 2131492888;
 			
-			// aapt resource value: 0x7f0b0024
-			public static int material_deep_teal_500 = 2131427364;
+			// aapt resource value: 0x7f0c0019
+			public static int dim_foreground_material_light = 2131492889;
 			
-			// aapt resource value: 0x7f0b0025
-			public static int material_grey_100 = 2131427365;
+			// aapt resource value: 0x7f0c001a
+			public static int error_color_material = 2131492890;
 			
-			// aapt resource value: 0x7f0b0026
-			public static int material_grey_300 = 2131427366;
+			// aapt resource value: 0x7f0c001b
+			public static int foreground_material_dark = 2131492891;
 			
-			// aapt resource value: 0x7f0b0027
-			public static int material_grey_50 = 2131427367;
+			// aapt resource value: 0x7f0c001c
+			public static int foreground_material_light = 2131492892;
 			
-			// aapt resource value: 0x7f0b0028
-			public static int material_grey_600 = 2131427368;
+			// aapt resource value: 0x7f0c001d
+			public static int highlighted_text_material_dark = 2131492893;
 			
-			// aapt resource value: 0x7f0b0029
-			public static int material_grey_800 = 2131427369;
+			// aapt resource value: 0x7f0c001e
+			public static int highlighted_text_material_light = 2131492894;
 			
-			// aapt resource value: 0x7f0b002a
-			public static int material_grey_850 = 2131427370;
+			// aapt resource value: 0x7f0c001f
+			public static int material_blue_grey_800 = 2131492895;
 			
-			// aapt resource value: 0x7f0b002b
-			public static int material_grey_900 = 2131427371;
+			// aapt resource value: 0x7f0c0020
+			public static int material_blue_grey_900 = 2131492896;
 			
-			// aapt resource value: 0x7f0b002c
-			public static int primary_dark_material_dark = 2131427372;
+			// aapt resource value: 0x7f0c0021
+			public static int material_blue_grey_950 = 2131492897;
 			
-			// aapt resource value: 0x7f0b002d
-			public static int primary_dark_material_light = 2131427373;
+			// aapt resource value: 0x7f0c0022
+			public static int material_deep_teal_200 = 2131492898;
 			
-			// aapt resource value: 0x7f0b002e
-			public static int primary_material_dark = 2131427374;
+			// aapt resource value: 0x7f0c0023
+			public static int material_deep_teal_500 = 2131492899;
 			
-			// aapt resource value: 0x7f0b002f
-			public static int primary_material_light = 2131427375;
+			// aapt resource value: 0x7f0c0024
+			public static int material_grey_100 = 2131492900;
 			
-			// aapt resource value: 0x7f0b0030
-			public static int primary_text_default_material_dark = 2131427376;
+			// aapt resource value: 0x7f0c0025
+			public static int material_grey_300 = 2131492901;
 			
-			// aapt resource value: 0x7f0b0031
-			public static int primary_text_default_material_light = 2131427377;
+			// aapt resource value: 0x7f0c0026
+			public static int material_grey_50 = 2131492902;
 			
-			// aapt resource value: 0x7f0b0032
-			public static int primary_text_disabled_material_dark = 2131427378;
+			// aapt resource value: 0x7f0c0027
+			public static int material_grey_600 = 2131492903;
 			
-			// aapt resource value: 0x7f0b0033
-			public static int primary_text_disabled_material_light = 2131427379;
+			// aapt resource value: 0x7f0c0028
+			public static int material_grey_800 = 2131492904;
 			
-			// aapt resource value: 0x7f0b0034
-			public static int ripple_material_dark = 2131427380;
+			// aapt resource value: 0x7f0c0029
+			public static int material_grey_850 = 2131492905;
 			
-			// aapt resource value: 0x7f0b0035
-			public static int ripple_material_light = 2131427381;
+			// aapt resource value: 0x7f0c002a
+			public static int material_grey_900 = 2131492906;
 			
-			// aapt resource value: 0x7f0b0036
-			public static int secondary_text_default_material_dark = 2131427382;
+			// aapt resource value: 0x7f0c0049
+			public static int notification_action_color_filter = 2131492937;
 			
-			// aapt resource value: 0x7f0b0037
-			public static int secondary_text_default_material_light = 2131427383;
+			// aapt resource value: 0x7f0c004a
+			public static int notification_icon_bg_color = 2131492938;
 			
-			// aapt resource value: 0x7f0b0038
-			public static int secondary_text_disabled_material_dark = 2131427384;
+			// aapt resource value: 0x7f0c003f
+			public static int notification_material_background_media_default_color = 2131492927;
 			
-			// aapt resource value: 0x7f0b0039
-			public static int secondary_text_disabled_material_light = 2131427385;
+			// aapt resource value: 0x7f0c002b
+			public static int primary_dark_material_dark = 2131492907;
 			
-			// aapt resource value: 0x7f0b003a
-			public static int switch_thumb_disabled_material_dark = 2131427386;
+			// aapt resource value: 0x7f0c002c
+			public static int primary_dark_material_light = 2131492908;
 			
-			// aapt resource value: 0x7f0b003b
-			public static int switch_thumb_disabled_material_light = 2131427387;
+			// aapt resource value: 0x7f0c002d
+			public static int primary_material_dark = 2131492909;
 			
-			// aapt resource value: 0x7f0b0052
-			public static int switch_thumb_material_dark = 2131427410;
+			// aapt resource value: 0x7f0c002e
+			public static int primary_material_light = 2131492910;
 			
-			// aapt resource value: 0x7f0b0053
-			public static int switch_thumb_material_light = 2131427411;
+			// aapt resource value: 0x7f0c002f
+			public static int primary_text_default_material_dark = 2131492911;
 			
-			// aapt resource value: 0x7f0b003c
-			public static int switch_thumb_normal_material_dark = 2131427388;
+			// aapt resource value: 0x7f0c0030
+			public static int primary_text_default_material_light = 2131492912;
 			
-			// aapt resource value: 0x7f0b003d
-			public static int switch_thumb_normal_material_light = 2131427389;
+			// aapt resource value: 0x7f0c0031
+			public static int primary_text_disabled_material_dark = 2131492913;
+			
+			// aapt resource value: 0x7f0c0032
+			public static int primary_text_disabled_material_light = 2131492914;
+			
+			// aapt resource value: 0x7f0c0033
+			public static int ripple_material_dark = 2131492915;
+			
+			// aapt resource value: 0x7f0c0034
+			public static int ripple_material_light = 2131492916;
+			
+			// aapt resource value: 0x7f0c0035
+			public static int secondary_text_default_material_dark = 2131492917;
+			
+			// aapt resource value: 0x7f0c0036
+			public static int secondary_text_default_material_light = 2131492918;
+			
+			// aapt resource value: 0x7f0c0037
+			public static int secondary_text_disabled_material_dark = 2131492919;
+			
+			// aapt resource value: 0x7f0c0038
+			public static int secondary_text_disabled_material_light = 2131492920;
+			
+			// aapt resource value: 0x7f0c0039
+			public static int switch_thumb_disabled_material_dark = 2131492921;
+			
+			// aapt resource value: 0x7f0c003a
+			public static int switch_thumb_disabled_material_light = 2131492922;
+			
+			// aapt resource value: 0x7f0c0061
+			public static int switch_thumb_material_dark = 2131492961;
+			
+			// aapt resource value: 0x7f0c0062
+			public static int switch_thumb_material_light = 2131492962;
+			
+			// aapt resource value: 0x7f0c003b
+			public static int switch_thumb_normal_material_dark = 2131492923;
+			
+			// aapt resource value: 0x7f0c003c
+			public static int switch_thumb_normal_material_light = 2131492924;
+			
+			// aapt resource value: 0x7f0c003d
+			public static int tooltip_background_dark = 2131492925;
+			
+			// aapt resource value: 0x7f0c003e
+			public static int tooltip_background_light = 2131492926;
 			
 			static Color()
 			{
@@ -1351,353 +1568,497 @@ namespace SuaveControls.MaterialForms.Android
 		public partial class Dimension
 		{
 			
-			// aapt resource value: 0x7f060019
-			public static int abc_action_bar_content_inset_material = 2131099673;
+			// aapt resource value: 0x7f07001b
+			public static int abc_action_bar_content_inset_material = 2131165211;
 			
-			// aapt resource value: 0x7f06000d
-			public static int abc_action_bar_default_height_material = 2131099661;
+			// aapt resource value: 0x7f07001c
+			public static int abc_action_bar_content_inset_with_nav = 2131165212;
 			
-			// aapt resource value: 0x7f06001a
-			public static int abc_action_bar_default_padding_end_material = 2131099674;
+			// aapt resource value: 0x7f070010
+			public static int abc_action_bar_default_height_material = 2131165200;
 			
-			// aapt resource value: 0x7f06001b
-			public static int abc_action_bar_default_padding_start_material = 2131099675;
+			// aapt resource value: 0x7f07001d
+			public static int abc_action_bar_default_padding_end_material = 2131165213;
 			
-			// aapt resource value: 0x7f06001d
-			public static int abc_action_bar_icon_vertical_padding_material = 2131099677;
+			// aapt resource value: 0x7f07001e
+			public static int abc_action_bar_default_padding_start_material = 2131165214;
 			
-			// aapt resource value: 0x7f06001e
-			public static int abc_action_bar_overflow_padding_end_material = 2131099678;
+			// aapt resource value: 0x7f070020
+			public static int abc_action_bar_elevation_material = 2131165216;
 			
-			// aapt resource value: 0x7f06001f
-			public static int abc_action_bar_overflow_padding_start_material = 2131099679;
+			// aapt resource value: 0x7f070021
+			public static int abc_action_bar_icon_vertical_padding_material = 2131165217;
 			
-			// aapt resource value: 0x7f06000e
-			public static int abc_action_bar_progress_bar_size = 2131099662;
+			// aapt resource value: 0x7f070022
+			public static int abc_action_bar_overflow_padding_end_material = 2131165218;
 			
-			// aapt resource value: 0x7f060020
-			public static int abc_action_bar_stacked_max_height = 2131099680;
+			// aapt resource value: 0x7f070023
+			public static int abc_action_bar_overflow_padding_start_material = 2131165219;
 			
-			// aapt resource value: 0x7f060021
-			public static int abc_action_bar_stacked_tab_max_width = 2131099681;
+			// aapt resource value: 0x7f070011
+			public static int abc_action_bar_progress_bar_size = 2131165201;
 			
-			// aapt resource value: 0x7f060022
-			public static int abc_action_bar_subtitle_bottom_margin_material = 2131099682;
+			// aapt resource value: 0x7f070024
+			public static int abc_action_bar_stacked_max_height = 2131165220;
 			
-			// aapt resource value: 0x7f060023
-			public static int abc_action_bar_subtitle_top_margin_material = 2131099683;
+			// aapt resource value: 0x7f070025
+			public static int abc_action_bar_stacked_tab_max_width = 2131165221;
 			
-			// aapt resource value: 0x7f060024
-			public static int abc_action_button_min_height_material = 2131099684;
+			// aapt resource value: 0x7f070026
+			public static int abc_action_bar_subtitle_bottom_margin_material = 2131165222;
 			
-			// aapt resource value: 0x7f060025
-			public static int abc_action_button_min_width_material = 2131099685;
+			// aapt resource value: 0x7f070027
+			public static int abc_action_bar_subtitle_top_margin_material = 2131165223;
 			
-			// aapt resource value: 0x7f060026
-			public static int abc_action_button_min_width_overflow_material = 2131099686;
+			// aapt resource value: 0x7f070028
+			public static int abc_action_button_min_height_material = 2131165224;
 			
-			// aapt resource value: 0x7f06000c
-			public static int abc_alert_dialog_button_bar_height = 2131099660;
+			// aapt resource value: 0x7f070029
+			public static int abc_action_button_min_width_material = 2131165225;
 			
-			// aapt resource value: 0x7f060027
-			public static int abc_button_inset_horizontal_material = 2131099687;
+			// aapt resource value: 0x7f07002a
+			public static int abc_action_button_min_width_overflow_material = 2131165226;
 			
-			// aapt resource value: 0x7f060028
-			public static int abc_button_inset_vertical_material = 2131099688;
+			// aapt resource value: 0x7f07000f
+			public static int abc_alert_dialog_button_bar_height = 2131165199;
 			
-			// aapt resource value: 0x7f060029
-			public static int abc_button_padding_horizontal_material = 2131099689;
+			// aapt resource value: 0x7f07002b
+			public static int abc_button_inset_horizontal_material = 2131165227;
 			
-			// aapt resource value: 0x7f06002a
-			public static int abc_button_padding_vertical_material = 2131099690;
+			// aapt resource value: 0x7f07002c
+			public static int abc_button_inset_vertical_material = 2131165228;
 			
-			// aapt resource value: 0x7f060011
-			public static int abc_config_prefDialogWidth = 2131099665;
+			// aapt resource value: 0x7f07002d
+			public static int abc_button_padding_horizontal_material = 2131165229;
 			
-			// aapt resource value: 0x7f06002b
-			public static int abc_control_corner_material = 2131099691;
+			// aapt resource value: 0x7f07002e
+			public static int abc_button_padding_vertical_material = 2131165230;
 			
-			// aapt resource value: 0x7f06002c
-			public static int abc_control_inset_material = 2131099692;
+			// aapt resource value: 0x7f07002f
+			public static int abc_cascading_menus_min_smallest_width = 2131165231;
 			
-			// aapt resource value: 0x7f06002d
-			public static int abc_control_padding_material = 2131099693;
+			// aapt resource value: 0x7f070014
+			public static int abc_config_prefDialogWidth = 2131165204;
 			
-			// aapt resource value: 0x7f060012
-			public static int abc_dialog_fixed_height_major = 2131099666;
+			// aapt resource value: 0x7f070030
+			public static int abc_control_corner_material = 2131165232;
 			
-			// aapt resource value: 0x7f060013
-			public static int abc_dialog_fixed_height_minor = 2131099667;
+			// aapt resource value: 0x7f070031
+			public static int abc_control_inset_material = 2131165233;
 			
-			// aapt resource value: 0x7f060014
-			public static int abc_dialog_fixed_width_major = 2131099668;
+			// aapt resource value: 0x7f070032
+			public static int abc_control_padding_material = 2131165234;
 			
-			// aapt resource value: 0x7f060015
-			public static int abc_dialog_fixed_width_minor = 2131099669;
+			// aapt resource value: 0x7f070015
+			public static int abc_dialog_fixed_height_major = 2131165205;
 			
-			// aapt resource value: 0x7f06002e
-			public static int abc_dialog_list_padding_vertical_material = 2131099694;
+			// aapt resource value: 0x7f070016
+			public static int abc_dialog_fixed_height_minor = 2131165206;
 			
-			// aapt resource value: 0x7f060016
-			public static int abc_dialog_min_width_major = 2131099670;
+			// aapt resource value: 0x7f070017
+			public static int abc_dialog_fixed_width_major = 2131165207;
 			
-			// aapt resource value: 0x7f060017
-			public static int abc_dialog_min_width_minor = 2131099671;
+			// aapt resource value: 0x7f070018
+			public static int abc_dialog_fixed_width_minor = 2131165208;
 			
-			// aapt resource value: 0x7f06002f
-			public static int abc_dialog_padding_material = 2131099695;
+			// aapt resource value: 0x7f070033
+			public static int abc_dialog_list_padding_bottom_no_buttons = 2131165235;
 			
-			// aapt resource value: 0x7f060030
-			public static int abc_dialog_padding_top_material = 2131099696;
+			// aapt resource value: 0x7f070034
+			public static int abc_dialog_list_padding_top_no_title = 2131165236;
 			
-			// aapt resource value: 0x7f060031
-			public static int abc_disabled_alpha_material_dark = 2131099697;
+			// aapt resource value: 0x7f070019
+			public static int abc_dialog_min_width_major = 2131165209;
 			
-			// aapt resource value: 0x7f060032
-			public static int abc_disabled_alpha_material_light = 2131099698;
+			// aapt resource value: 0x7f07001a
+			public static int abc_dialog_min_width_minor = 2131165210;
 			
-			// aapt resource value: 0x7f060033
-			public static int abc_dropdownitem_icon_width = 2131099699;
+			// aapt resource value: 0x7f070035
+			public static int abc_dialog_padding_material = 2131165237;
 			
-			// aapt resource value: 0x7f060034
-			public static int abc_dropdownitem_text_padding_left = 2131099700;
+			// aapt resource value: 0x7f070036
+			public static int abc_dialog_padding_top_material = 2131165238;
 			
-			// aapt resource value: 0x7f060035
-			public static int abc_dropdownitem_text_padding_right = 2131099701;
+			// aapt resource value: 0x7f070037
+			public static int abc_dialog_title_divider_material = 2131165239;
 			
-			// aapt resource value: 0x7f060036
-			public static int abc_edit_text_inset_bottom_material = 2131099702;
+			// aapt resource value: 0x7f070038
+			public static int abc_disabled_alpha_material_dark = 2131165240;
 			
-			// aapt resource value: 0x7f060037
-			public static int abc_edit_text_inset_horizontal_material = 2131099703;
+			// aapt resource value: 0x7f070039
+			public static int abc_disabled_alpha_material_light = 2131165241;
 			
-			// aapt resource value: 0x7f060038
-			public static int abc_edit_text_inset_top_material = 2131099704;
+			// aapt resource value: 0x7f07003a
+			public static int abc_dropdownitem_icon_width = 2131165242;
 			
-			// aapt resource value: 0x7f060039
-			public static int abc_floating_window_z = 2131099705;
+			// aapt resource value: 0x7f07003b
+			public static int abc_dropdownitem_text_padding_left = 2131165243;
 			
-			// aapt resource value: 0x7f06003a
-			public static int abc_list_item_padding_horizontal_material = 2131099706;
+			// aapt resource value: 0x7f07003c
+			public static int abc_dropdownitem_text_padding_right = 2131165244;
 			
-			// aapt resource value: 0x7f06003b
-			public static int abc_panel_menu_list_width = 2131099707;
+			// aapt resource value: 0x7f07003d
+			public static int abc_edit_text_inset_bottom_material = 2131165245;
 			
-			// aapt resource value: 0x7f06003c
-			public static int abc_search_view_preferred_width = 2131099708;
+			// aapt resource value: 0x7f07003e
+			public static int abc_edit_text_inset_horizontal_material = 2131165246;
 			
-			// aapt resource value: 0x7f060018
-			public static int abc_search_view_text_min_width = 2131099672;
+			// aapt resource value: 0x7f07003f
+			public static int abc_edit_text_inset_top_material = 2131165247;
 			
-			// aapt resource value: 0x7f06003d
-			public static int abc_seekbar_track_background_height_material = 2131099709;
+			// aapt resource value: 0x7f070040
+			public static int abc_floating_window_z = 2131165248;
 			
-			// aapt resource value: 0x7f06003e
-			public static int abc_seekbar_track_progress_height_material = 2131099710;
+			// aapt resource value: 0x7f070041
+			public static int abc_list_item_padding_horizontal_material = 2131165249;
 			
-			// aapt resource value: 0x7f06003f
-			public static int abc_select_dialog_padding_start_material = 2131099711;
+			// aapt resource value: 0x7f070042
+			public static int abc_panel_menu_list_width = 2131165250;
 			
-			// aapt resource value: 0x7f06001c
-			public static int abc_switch_padding = 2131099676;
+			// aapt resource value: 0x7f070043
+			public static int abc_progress_bar_height_material = 2131165251;
 			
-			// aapt resource value: 0x7f060040
-			public static int abc_text_size_body_1_material = 2131099712;
+			// aapt resource value: 0x7f070044
+			public static int abc_search_view_preferred_height = 2131165252;
 			
-			// aapt resource value: 0x7f060041
-			public static int abc_text_size_body_2_material = 2131099713;
+			// aapt resource value: 0x7f070045
+			public static int abc_search_view_preferred_width = 2131165253;
 			
-			// aapt resource value: 0x7f060042
-			public static int abc_text_size_button_material = 2131099714;
+			// aapt resource value: 0x7f070046
+			public static int abc_seekbar_track_background_height_material = 2131165254;
 			
-			// aapt resource value: 0x7f060043
-			public static int abc_text_size_caption_material = 2131099715;
+			// aapt resource value: 0x7f070047
+			public static int abc_seekbar_track_progress_height_material = 2131165255;
 			
-			// aapt resource value: 0x7f060044
-			public static int abc_text_size_display_1_material = 2131099716;
+			// aapt resource value: 0x7f070048
+			public static int abc_select_dialog_padding_start_material = 2131165256;
 			
-			// aapt resource value: 0x7f060045
-			public static int abc_text_size_display_2_material = 2131099717;
+			// aapt resource value: 0x7f07001f
+			public static int abc_switch_padding = 2131165215;
 			
-			// aapt resource value: 0x7f060046
-			public static int abc_text_size_display_3_material = 2131099718;
+			// aapt resource value: 0x7f070049
+			public static int abc_text_size_body_1_material = 2131165257;
 			
-			// aapt resource value: 0x7f060047
-			public static int abc_text_size_display_4_material = 2131099719;
+			// aapt resource value: 0x7f07004a
+			public static int abc_text_size_body_2_material = 2131165258;
 			
-			// aapt resource value: 0x7f060048
-			public static int abc_text_size_headline_material = 2131099720;
+			// aapt resource value: 0x7f07004b
+			public static int abc_text_size_button_material = 2131165259;
 			
-			// aapt resource value: 0x7f060049
-			public static int abc_text_size_large_material = 2131099721;
+			// aapt resource value: 0x7f07004c
+			public static int abc_text_size_caption_material = 2131165260;
 			
-			// aapt resource value: 0x7f06004a
-			public static int abc_text_size_medium_material = 2131099722;
+			// aapt resource value: 0x7f07004d
+			public static int abc_text_size_display_1_material = 2131165261;
 			
-			// aapt resource value: 0x7f06004b
-			public static int abc_text_size_menu_material = 2131099723;
+			// aapt resource value: 0x7f07004e
+			public static int abc_text_size_display_2_material = 2131165262;
 			
-			// aapt resource value: 0x7f06004c
-			public static int abc_text_size_small_material = 2131099724;
+			// aapt resource value: 0x7f07004f
+			public static int abc_text_size_display_3_material = 2131165263;
 			
-			// aapt resource value: 0x7f06004d
-			public static int abc_text_size_subhead_material = 2131099725;
+			// aapt resource value: 0x7f070050
+			public static int abc_text_size_display_4_material = 2131165264;
 			
-			// aapt resource value: 0x7f06000f
-			public static int abc_text_size_subtitle_material_toolbar = 2131099663;
+			// aapt resource value: 0x7f070051
+			public static int abc_text_size_headline_material = 2131165265;
 			
-			// aapt resource value: 0x7f06004e
-			public static int abc_text_size_title_material = 2131099726;
+			// aapt resource value: 0x7f070052
+			public static int abc_text_size_large_material = 2131165266;
 			
-			// aapt resource value: 0x7f060010
-			public static int abc_text_size_title_material_toolbar = 2131099664;
+			// aapt resource value: 0x7f070053
+			public static int abc_text_size_medium_material = 2131165267;
 			
-			// aapt resource value: 0x7f060009
-			public static int cardview_compat_inset_shadow = 2131099657;
+			// aapt resource value: 0x7f070054
+			public static int abc_text_size_menu_header_material = 2131165268;
 			
-			// aapt resource value: 0x7f06000a
-			public static int cardview_default_elevation = 2131099658;
+			// aapt resource value: 0x7f070055
+			public static int abc_text_size_menu_material = 2131165269;
 			
-			// aapt resource value: 0x7f06000b
-			public static int cardview_default_radius = 2131099659;
+			// aapt resource value: 0x7f070056
+			public static int abc_text_size_small_material = 2131165270;
 			
-			// aapt resource value: 0x7f06005f
-			public static int design_appbar_elevation = 2131099743;
+			// aapt resource value: 0x7f070057
+			public static int abc_text_size_subhead_material = 2131165271;
 			
-			// aapt resource value: 0x7f060060
-			public static int design_bottom_sheet_modal_elevation = 2131099744;
+			// aapt resource value: 0x7f070012
+			public static int abc_text_size_subtitle_material_toolbar = 2131165202;
 			
-			// aapt resource value: 0x7f060061
-			public static int design_bottom_sheet_modal_peek_height = 2131099745;
+			// aapt resource value: 0x7f070058
+			public static int abc_text_size_title_material = 2131165272;
 			
-			// aapt resource value: 0x7f060062
-			public static int design_fab_border_width = 2131099746;
+			// aapt resource value: 0x7f070013
+			public static int abc_text_size_title_material_toolbar = 2131165203;
 			
-			// aapt resource value: 0x7f060063
-			public static int design_fab_elevation = 2131099747;
+			// aapt resource value: 0x7f07000c
+			public static int cardview_compat_inset_shadow = 2131165196;
 			
-			// aapt resource value: 0x7f060064
-			public static int design_fab_image_size = 2131099748;
+			// aapt resource value: 0x7f07000d
+			public static int cardview_default_elevation = 2131165197;
 			
-			// aapt resource value: 0x7f060065
-			public static int design_fab_size_mini = 2131099749;
+			// aapt resource value: 0x7f07000e
+			public static int cardview_default_radius = 2131165198;
 			
-			// aapt resource value: 0x7f060066
-			public static int design_fab_size_normal = 2131099750;
+			// aapt resource value: 0x7f070094
+			public static int compat_button_inset_horizontal_material = 2131165332;
 			
-			// aapt resource value: 0x7f060067
-			public static int design_fab_translation_z_pressed = 2131099751;
+			// aapt resource value: 0x7f070095
+			public static int compat_button_inset_vertical_material = 2131165333;
 			
-			// aapt resource value: 0x7f060068
-			public static int design_navigation_elevation = 2131099752;
+			// aapt resource value: 0x7f070096
+			public static int compat_button_padding_horizontal_material = 2131165334;
 			
-			// aapt resource value: 0x7f060069
-			public static int design_navigation_icon_padding = 2131099753;
+			// aapt resource value: 0x7f070097
+			public static int compat_button_padding_vertical_material = 2131165335;
 			
-			// aapt resource value: 0x7f06006a
-			public static int design_navigation_icon_size = 2131099754;
+			// aapt resource value: 0x7f070098
+			public static int compat_control_corner_material = 2131165336;
 			
-			// aapt resource value: 0x7f060057
-			public static int design_navigation_max_width = 2131099735;
+			// aapt resource value: 0x7f070072
+			public static int design_appbar_elevation = 2131165298;
 			
-			// aapt resource value: 0x7f06006b
-			public static int design_navigation_padding_bottom = 2131099755;
+			// aapt resource value: 0x7f070073
+			public static int design_bottom_navigation_active_item_max_width = 2131165299;
 			
-			// aapt resource value: 0x7f06006c
-			public static int design_navigation_separator_vertical_padding = 2131099756;
+			// aapt resource value: 0x7f070074
+			public static int design_bottom_navigation_active_text_size = 2131165300;
 			
-			// aapt resource value: 0x7f060058
-			public static int design_snackbar_action_inline_max_width = 2131099736;
+			// aapt resource value: 0x7f070075
+			public static int design_bottom_navigation_elevation = 2131165301;
 			
-			// aapt resource value: 0x7f060059
-			public static int design_snackbar_background_corner_radius = 2131099737;
+			// aapt resource value: 0x7f070076
+			public static int design_bottom_navigation_height = 2131165302;
 			
-			// aapt resource value: 0x7f06006d
-			public static int design_snackbar_elevation = 2131099757;
+			// aapt resource value: 0x7f070077
+			public static int design_bottom_navigation_item_max_width = 2131165303;
 			
-			// aapt resource value: 0x7f06005a
-			public static int design_snackbar_extra_spacing_horizontal = 2131099738;
+			// aapt resource value: 0x7f070078
+			public static int design_bottom_navigation_item_min_width = 2131165304;
 			
-			// aapt resource value: 0x7f06005b
-			public static int design_snackbar_max_width = 2131099739;
+			// aapt resource value: 0x7f070079
+			public static int design_bottom_navigation_margin = 2131165305;
 			
-			// aapt resource value: 0x7f06005c
-			public static int design_snackbar_min_width = 2131099740;
+			// aapt resource value: 0x7f07007a
+			public static int design_bottom_navigation_shadow_height = 2131165306;
 			
-			// aapt resource value: 0x7f06006e
-			public static int design_snackbar_padding_horizontal = 2131099758;
+			// aapt resource value: 0x7f07007b
+			public static int design_bottom_navigation_text_size = 2131165307;
 			
-			// aapt resource value: 0x7f06006f
-			public static int design_snackbar_padding_vertical = 2131099759;
+			// aapt resource value: 0x7f07007c
+			public static int design_bottom_sheet_modal_elevation = 2131165308;
 			
-			// aapt resource value: 0x7f06005d
-			public static int design_snackbar_padding_vertical_2lines = 2131099741;
+			// aapt resource value: 0x7f07007d
+			public static int design_bottom_sheet_peek_height_min = 2131165309;
 			
-			// aapt resource value: 0x7f060070
-			public static int design_snackbar_text_size = 2131099760;
+			// aapt resource value: 0x7f07007e
+			public static int design_fab_border_width = 2131165310;
 			
-			// aapt resource value: 0x7f060071
-			public static int design_tab_max_width = 2131099761;
+			// aapt resource value: 0x7f07007f
+			public static int design_fab_elevation = 2131165311;
 			
-			// aapt resource value: 0x7f06005e
-			public static int design_tab_scrollable_min_width = 2131099742;
+			// aapt resource value: 0x7f070080
+			public static int design_fab_image_size = 2131165312;
 			
-			// aapt resource value: 0x7f060072
-			public static int design_tab_text_size = 2131099762;
+			// aapt resource value: 0x7f070081
+			public static int design_fab_size_mini = 2131165313;
 			
-			// aapt resource value: 0x7f060073
-			public static int design_tab_text_size_2line = 2131099763;
+			// aapt resource value: 0x7f070082
+			public static int design_fab_size_normal = 2131165314;
 			
-			// aapt resource value: 0x7f06004f
-			public static int disabled_alpha_material_dark = 2131099727;
+			// aapt resource value: 0x7f070083
+			public static int design_fab_translation_z_pressed = 2131165315;
 			
-			// aapt resource value: 0x7f060050
-			public static int disabled_alpha_material_light = 2131099728;
+			// aapt resource value: 0x7f070084
+			public static int design_navigation_elevation = 2131165316;
 			
-			// aapt resource value: 0x7f060051
-			public static int highlight_alpha_material_colored = 2131099729;
+			// aapt resource value: 0x7f070085
+			public static int design_navigation_icon_padding = 2131165317;
 			
-			// aapt resource value: 0x7f060052
-			public static int highlight_alpha_material_dark = 2131099730;
+			// aapt resource value: 0x7f070086
+			public static int design_navigation_icon_size = 2131165318;
 			
-			// aapt resource value: 0x7f060053
-			public static int highlight_alpha_material_light = 2131099731;
+			// aapt resource value: 0x7f07006a
+			public static int design_navigation_max_width = 2131165290;
 			
-			// aapt resource value: 0x7f060000
-			public static int item_touch_helper_max_drag_scroll_per_frame = 2131099648;
+			// aapt resource value: 0x7f070087
+			public static int design_navigation_padding_bottom = 2131165319;
 			
-			// aapt resource value: 0x7f060001
-			public static int item_touch_helper_swipe_escape_max_velocity = 2131099649;
+			// aapt resource value: 0x7f070088
+			public static int design_navigation_separator_vertical_padding = 2131165320;
 			
-			// aapt resource value: 0x7f060002
-			public static int item_touch_helper_swipe_escape_velocity = 2131099650;
+			// aapt resource value: 0x7f07006b
+			public static int design_snackbar_action_inline_max_width = 2131165291;
 			
-			// aapt resource value: 0x7f060003
-			public static int mr_controller_volume_group_list_item_height = 2131099651;
+			// aapt resource value: 0x7f07006c
+			public static int design_snackbar_background_corner_radius = 2131165292;
 			
-			// aapt resource value: 0x7f060004
-			public static int mr_controller_volume_group_list_item_icon_size = 2131099652;
+			// aapt resource value: 0x7f070089
+			public static int design_snackbar_elevation = 2131165321;
 			
-			// aapt resource value: 0x7f060005
-			public static int mr_controller_volume_group_list_max_height = 2131099653;
+			// aapt resource value: 0x7f07006d
+			public static int design_snackbar_extra_spacing_horizontal = 2131165293;
 			
-			// aapt resource value: 0x7f060008
-			public static int mr_controller_volume_group_list_padding_top = 2131099656;
+			// aapt resource value: 0x7f07006e
+			public static int design_snackbar_max_width = 2131165294;
 			
-			// aapt resource value: 0x7f060006
-			public static int mr_dialog_fixed_width_major = 2131099654;
+			// aapt resource value: 0x7f07006f
+			public static int design_snackbar_min_width = 2131165295;
 			
-			// aapt resource value: 0x7f060007
-			public static int mr_dialog_fixed_width_minor = 2131099655;
+			// aapt resource value: 0x7f07008a
+			public static int design_snackbar_padding_horizontal = 2131165322;
 			
-			// aapt resource value: 0x7f060054
-			public static int notification_large_icon_height = 2131099732;
+			// aapt resource value: 0x7f07008b
+			public static int design_snackbar_padding_vertical = 2131165323;
 			
-			// aapt resource value: 0x7f060055
-			public static int notification_large_icon_width = 2131099733;
+			// aapt resource value: 0x7f070070
+			public static int design_snackbar_padding_vertical_2lines = 2131165296;
 			
-			// aapt resource value: 0x7f060056
-			public static int notification_subtext_size = 2131099734;
+			// aapt resource value: 0x7f07008c
+			public static int design_snackbar_text_size = 2131165324;
+			
+			// aapt resource value: 0x7f07008d
+			public static int design_tab_max_width = 2131165325;
+			
+			// aapt resource value: 0x7f070071
+			public static int design_tab_scrollable_min_width = 2131165297;
+			
+			// aapt resource value: 0x7f07008e
+			public static int design_tab_text_size = 2131165326;
+			
+			// aapt resource value: 0x7f07008f
+			public static int design_tab_text_size_2line = 2131165327;
+			
+			// aapt resource value: 0x7f070059
+			public static int disabled_alpha_material_dark = 2131165273;
+			
+			// aapt resource value: 0x7f07005a
+			public static int disabled_alpha_material_light = 2131165274;
+			
+			// aapt resource value: 0x7f070000
+			public static int fastscroll_default_thickness = 2131165184;
+			
+			// aapt resource value: 0x7f070001
+			public static int fastscroll_margin = 2131165185;
+			
+			// aapt resource value: 0x7f070002
+			public static int fastscroll_minimum_range = 2131165186;
+			
+			// aapt resource value: 0x7f07005b
+			public static int highlight_alpha_material_colored = 2131165275;
+			
+			// aapt resource value: 0x7f07005c
+			public static int highlight_alpha_material_dark = 2131165276;
+			
+			// aapt resource value: 0x7f07005d
+			public static int highlight_alpha_material_light = 2131165277;
+			
+			// aapt resource value: 0x7f07005e
+			public static int hint_alpha_material_dark = 2131165278;
+			
+			// aapt resource value: 0x7f07005f
+			public static int hint_alpha_material_light = 2131165279;
+			
+			// aapt resource value: 0x7f070060
+			public static int hint_pressed_alpha_material_dark = 2131165280;
+			
+			// aapt resource value: 0x7f070061
+			public static int hint_pressed_alpha_material_light = 2131165281;
+			
+			// aapt resource value: 0x7f070003
+			public static int item_touch_helper_max_drag_scroll_per_frame = 2131165187;
+			
+			// aapt resource value: 0x7f070004
+			public static int item_touch_helper_swipe_escape_max_velocity = 2131165188;
+			
+			// aapt resource value: 0x7f070005
+			public static int item_touch_helper_swipe_escape_velocity = 2131165189;
+			
+			// aapt resource value: 0x7f070006
+			public static int mr_controller_volume_group_list_item_height = 2131165190;
+			
+			// aapt resource value: 0x7f070007
+			public static int mr_controller_volume_group_list_item_icon_size = 2131165191;
+			
+			// aapt resource value: 0x7f070008
+			public static int mr_controller_volume_group_list_max_height = 2131165192;
+			
+			// aapt resource value: 0x7f07000b
+			public static int mr_controller_volume_group_list_padding_top = 2131165195;
+			
+			// aapt resource value: 0x7f070009
+			public static int mr_dialog_fixed_width_major = 2131165193;
+			
+			// aapt resource value: 0x7f07000a
+			public static int mr_dialog_fixed_width_minor = 2131165194;
+			
+			// aapt resource value: 0x7f070099
+			public static int notification_action_icon_size = 2131165337;
+			
+			// aapt resource value: 0x7f07009a
+			public static int notification_action_text_size = 2131165338;
+			
+			// aapt resource value: 0x7f07009b
+			public static int notification_big_circle_margin = 2131165339;
+			
+			// aapt resource value: 0x7f070091
+			public static int notification_content_margin_start = 2131165329;
+			
+			// aapt resource value: 0x7f07009c
+			public static int notification_large_icon_height = 2131165340;
+			
+			// aapt resource value: 0x7f07009d
+			public static int notification_large_icon_width = 2131165341;
+			
+			// aapt resource value: 0x7f070092
+			public static int notification_main_column_padding_top = 2131165330;
+			
+			// aapt resource value: 0x7f070093
+			public static int notification_media_narrow_margin = 2131165331;
+			
+			// aapt resource value: 0x7f07009e
+			public static int notification_right_icon_size = 2131165342;
+			
+			// aapt resource value: 0x7f070090
+			public static int notification_right_side_padding_top = 2131165328;
+			
+			// aapt resource value: 0x7f07009f
+			public static int notification_small_icon_background_padding = 2131165343;
+			
+			// aapt resource value: 0x7f0700a0
+			public static int notification_small_icon_size_as_large = 2131165344;
+			
+			// aapt resource value: 0x7f0700a1
+			public static int notification_subtext_size = 2131165345;
+			
+			// aapt resource value: 0x7f0700a2
+			public static int notification_top_pad = 2131165346;
+			
+			// aapt resource value: 0x7f0700a3
+			public static int notification_top_pad_large_text = 2131165347;
+			
+			// aapt resource value: 0x7f070062
+			public static int tooltip_corner_radius = 2131165282;
+			
+			// aapt resource value: 0x7f070063
+			public static int tooltip_horizontal_padding = 2131165283;
+			
+			// aapt resource value: 0x7f070064
+			public static int tooltip_margin = 2131165284;
+			
+			// aapt resource value: 0x7f070065
+			public static int tooltip_precise_anchor_extra_offset = 2131165285;
+			
+			// aapt resource value: 0x7f070066
+			public static int tooltip_precise_anchor_threshold = 2131165286;
+			
+			// aapt resource value: 0x7f070067
+			public static int tooltip_vertical_padding = 2131165287;
+			
+			// aapt resource value: 0x7f070068
+			public static int tooltip_y_offset_non_touch = 2131165288;
+			
+			// aapt resource value: 0x7f070069
+			public static int tooltip_y_offset_touch = 2131165289;
 			
 			static Dimension()
 			{
@@ -1746,85 +2107,85 @@ namespace SuaveControls.MaterialForms.Android
 			public static int abc_btn_radio_to_on_mtrl_015 = 2130837514;
 			
 			// aapt resource value: 0x7f02000b
-			public static int abc_btn_rating_star_off_mtrl_alpha = 2130837515;
+			public static int abc_btn_switch_to_on_mtrl_00001 = 2130837515;
 			
 			// aapt resource value: 0x7f02000c
-			public static int abc_btn_rating_star_on_mtrl_alpha = 2130837516;
+			public static int abc_btn_switch_to_on_mtrl_00012 = 2130837516;
 			
 			// aapt resource value: 0x7f02000d
-			public static int abc_btn_switch_to_on_mtrl_00001 = 2130837517;
+			public static int abc_cab_background_internal_bg = 2130837517;
 			
 			// aapt resource value: 0x7f02000e
-			public static int abc_btn_switch_to_on_mtrl_00012 = 2130837518;
+			public static int abc_cab_background_top_material = 2130837518;
 			
 			// aapt resource value: 0x7f02000f
-			public static int abc_cab_background_internal_bg = 2130837519;
+			public static int abc_cab_background_top_mtrl_alpha = 2130837519;
 			
 			// aapt resource value: 0x7f020010
-			public static int abc_cab_background_top_material = 2130837520;
+			public static int abc_control_background_material = 2130837520;
 			
 			// aapt resource value: 0x7f020011
-			public static int abc_cab_background_top_mtrl_alpha = 2130837521;
+			public static int abc_dialog_material_background = 2130837521;
 			
 			// aapt resource value: 0x7f020012
-			public static int abc_control_background_material = 2130837522;
+			public static int abc_edit_text_material = 2130837522;
 			
 			// aapt resource value: 0x7f020013
-			public static int abc_dialog_material_background_dark = 2130837523;
+			public static int abc_ic_ab_back_material = 2130837523;
 			
 			// aapt resource value: 0x7f020014
-			public static int abc_dialog_material_background_light = 2130837524;
+			public static int abc_ic_arrow_drop_right_black_24dp = 2130837524;
 			
 			// aapt resource value: 0x7f020015
-			public static int abc_edit_text_material = 2130837525;
+			public static int abc_ic_clear_material = 2130837525;
 			
 			// aapt resource value: 0x7f020016
-			public static int abc_ic_ab_back_mtrl_am_alpha = 2130837526;
+			public static int abc_ic_commit_search_api_mtrl_alpha = 2130837526;
 			
 			// aapt resource value: 0x7f020017
-			public static int abc_ic_clear_mtrl_alpha = 2130837527;
+			public static int abc_ic_go_search_api_material = 2130837527;
 			
 			// aapt resource value: 0x7f020018
-			public static int abc_ic_commit_search_api_mtrl_alpha = 2130837528;
+			public static int abc_ic_menu_copy_mtrl_am_alpha = 2130837528;
 			
 			// aapt resource value: 0x7f020019
-			public static int abc_ic_go_search_api_mtrl_alpha = 2130837529;
+			public static int abc_ic_menu_cut_mtrl_alpha = 2130837529;
 			
 			// aapt resource value: 0x7f02001a
-			public static int abc_ic_menu_copy_mtrl_am_alpha = 2130837530;
+			public static int abc_ic_menu_overflow_material = 2130837530;
 			
 			// aapt resource value: 0x7f02001b
-			public static int abc_ic_menu_cut_mtrl_alpha = 2130837531;
+			public static int abc_ic_menu_paste_mtrl_am_alpha = 2130837531;
 			
 			// aapt resource value: 0x7f02001c
-			public static int abc_ic_menu_moreoverflow_mtrl_alpha = 2130837532;
+			public static int abc_ic_menu_selectall_mtrl_alpha = 2130837532;
 			
 			// aapt resource value: 0x7f02001d
-			public static int abc_ic_menu_paste_mtrl_am_alpha = 2130837533;
+			public static int abc_ic_menu_share_mtrl_alpha = 2130837533;
 			
 			// aapt resource value: 0x7f02001e
-			public static int abc_ic_menu_selectall_mtrl_alpha = 2130837534;
+			public static int abc_ic_search_api_material = 2130837534;
 			
 			// aapt resource value: 0x7f02001f
-			public static int abc_ic_menu_share_mtrl_alpha = 2130837535;
+			public static int abc_ic_star_black_16dp = 2130837535;
 			
 			// aapt resource value: 0x7f020020
-			public static int abc_ic_search_api_mtrl_alpha = 2130837536;
+			public static int abc_ic_star_black_36dp = 2130837536;
 			
 			// aapt resource value: 0x7f020021
-			public static int abc_ic_star_black_16dp = 2130837537;
+			public static int abc_ic_star_black_48dp = 2130837537;
 			
 			// aapt resource value: 0x7f020022
-			public static int abc_ic_star_black_36dp = 2130837538;
+			public static int abc_ic_star_half_black_16dp = 2130837538;
 			
 			// aapt resource value: 0x7f020023
-			public static int abc_ic_star_half_black_16dp = 2130837539;
+			public static int abc_ic_star_half_black_36dp = 2130837539;
 			
 			// aapt resource value: 0x7f020024
-			public static int abc_ic_star_half_black_36dp = 2130837540;
+			public static int abc_ic_star_half_black_48dp = 2130837540;
 			
 			// aapt resource value: 0x7f020025
-			public static int abc_ic_voice_search_api_mtrl_alpha = 2130837541;
+			public static int abc_ic_voice_search_api_material = 2130837541;
 			
 			// aapt resource value: 0x7f020026
 			public static int abc_item_background_holo_dark = 2130837542;
@@ -1872,10 +2233,10 @@ namespace SuaveControls.MaterialForms.Android
 			public static int abc_popup_background_mtrl_mult = 2130837556;
 			
 			// aapt resource value: 0x7f020035
-			public static int abc_ratingbar_full_material = 2130837557;
+			public static int abc_ratingbar_indicator_material = 2130837557;
 			
 			// aapt resource value: 0x7f020036
-			public static int abc_ratingbar_indicator_material = 2130837558;
+			public static int abc_ratingbar_material = 2130837558;
 			
 			// aapt resource value: 0x7f020037
 			public static int abc_ratingbar_small_material = 2130837559;
@@ -1899,301 +2260,745 @@ namespace SuaveControls.MaterialForms.Android
 			public static int abc_seekbar_thumb_material = 2130837565;
 			
 			// aapt resource value: 0x7f02003e
-			public static int abc_seekbar_track_material = 2130837566;
+			public static int abc_seekbar_tick_mark_material = 2130837566;
 			
 			// aapt resource value: 0x7f02003f
-			public static int abc_spinner_mtrl_am_alpha = 2130837567;
+			public static int abc_seekbar_track_material = 2130837567;
 			
 			// aapt resource value: 0x7f020040
-			public static int abc_spinner_textfield_background_material = 2130837568;
+			public static int abc_spinner_mtrl_am_alpha = 2130837568;
 			
 			// aapt resource value: 0x7f020041
-			public static int abc_switch_thumb_material = 2130837569;
+			public static int abc_spinner_textfield_background_material = 2130837569;
 			
 			// aapt resource value: 0x7f020042
-			public static int abc_switch_track_mtrl_alpha = 2130837570;
+			public static int abc_switch_thumb_material = 2130837570;
 			
 			// aapt resource value: 0x7f020043
-			public static int abc_tab_indicator_material = 2130837571;
+			public static int abc_switch_track_mtrl_alpha = 2130837571;
 			
 			// aapt resource value: 0x7f020044
-			public static int abc_tab_indicator_mtrl_alpha = 2130837572;
+			public static int abc_tab_indicator_material = 2130837572;
 			
 			// aapt resource value: 0x7f020045
-			public static int abc_text_cursor_material = 2130837573;
+			public static int abc_tab_indicator_mtrl_alpha = 2130837573;
 			
 			// aapt resource value: 0x7f020046
-			public static int abc_textfield_activated_mtrl_alpha = 2130837574;
+			public static int abc_text_cursor_material = 2130837574;
 			
 			// aapt resource value: 0x7f020047
-			public static int abc_textfield_default_mtrl_alpha = 2130837575;
+			public static int abc_text_select_handle_left_mtrl_dark = 2130837575;
 			
 			// aapt resource value: 0x7f020048
-			public static int abc_textfield_search_activated_mtrl_alpha = 2130837576;
+			public static int abc_text_select_handle_left_mtrl_light = 2130837576;
 			
 			// aapt resource value: 0x7f020049
-			public static int abc_textfield_search_default_mtrl_alpha = 2130837577;
+			public static int abc_text_select_handle_middle_mtrl_dark = 2130837577;
 			
 			// aapt resource value: 0x7f02004a
-			public static int abc_textfield_search_material = 2130837578;
+			public static int abc_text_select_handle_middle_mtrl_light = 2130837578;
 			
 			// aapt resource value: 0x7f02004b
-			public static int design_fab_background = 2130837579;
+			public static int abc_text_select_handle_right_mtrl_dark = 2130837579;
 			
 			// aapt resource value: 0x7f02004c
-			public static int design_snackbar_background = 2130837580;
+			public static int abc_text_select_handle_right_mtrl_light = 2130837580;
 			
 			// aapt resource value: 0x7f02004d
-			public static int ic_audiotrack = 2130837581;
+			public static int abc_textfield_activated_mtrl_alpha = 2130837581;
 			
 			// aapt resource value: 0x7f02004e
-			public static int ic_audiotrack_light = 2130837582;
+			public static int abc_textfield_default_mtrl_alpha = 2130837582;
 			
 			// aapt resource value: 0x7f02004f
-			public static int ic_bluetooth_grey = 2130837583;
+			public static int abc_textfield_search_activated_mtrl_alpha = 2130837583;
 			
 			// aapt resource value: 0x7f020050
-			public static int ic_bluetooth_white = 2130837584;
+			public static int abc_textfield_search_default_mtrl_alpha = 2130837584;
 			
 			// aapt resource value: 0x7f020051
-			public static int ic_cast_dark = 2130837585;
+			public static int abc_textfield_search_material = 2130837585;
 			
 			// aapt resource value: 0x7f020052
-			public static int ic_cast_disabled_light = 2130837586;
+			public static int abc_vector_test = 2130837586;
 			
 			// aapt resource value: 0x7f020053
-			public static int ic_cast_grey = 2130837587;
+			public static int avd_hide_password = 2130837587;
+			
+			// aapt resource value: 0x7f02012f
+			public static int avd_hide_password_1 = 2130837807;
+			
+			// aapt resource value: 0x7f020130
+			public static int avd_hide_password_2 = 2130837808;
+			
+			// aapt resource value: 0x7f020131
+			public static int avd_hide_password_3 = 2130837809;
 			
 			// aapt resource value: 0x7f020054
-			public static int ic_cast_light = 2130837588;
+			public static int avd_show_password = 2130837588;
+			
+			// aapt resource value: 0x7f020132
+			public static int avd_show_password_1 = 2130837810;
+			
+			// aapt resource value: 0x7f020133
+			public static int avd_show_password_2 = 2130837811;
+			
+			// aapt resource value: 0x7f020134
+			public static int avd_show_password_3 = 2130837812;
 			
 			// aapt resource value: 0x7f020055
-			public static int ic_cast_off_light = 2130837589;
+			public static int design_bottom_navigation_item_background = 2130837589;
 			
 			// aapt resource value: 0x7f020056
-			public static int ic_cast_on_0_light = 2130837590;
+			public static int design_fab_background = 2130837590;
 			
 			// aapt resource value: 0x7f020057
-			public static int ic_cast_on_1_light = 2130837591;
+			public static int design_ic_visibility = 2130837591;
 			
 			// aapt resource value: 0x7f020058
-			public static int ic_cast_on_2_light = 2130837592;
+			public static int design_ic_visibility_off = 2130837592;
 			
 			// aapt resource value: 0x7f020059
-			public static int ic_cast_on_light = 2130837593;
+			public static int design_password_eye = 2130837593;
 			
 			// aapt resource value: 0x7f02005a
-			public static int ic_cast_white = 2130837594;
+			public static int design_snackbar_background = 2130837594;
 			
 			// aapt resource value: 0x7f02005b
-			public static int ic_close_dark = 2130837595;
+			public static int ic_audiotrack_dark = 2130837595;
 			
 			// aapt resource value: 0x7f02005c
-			public static int ic_close_light = 2130837596;
+			public static int ic_audiotrack_light = 2130837596;
 			
 			// aapt resource value: 0x7f02005d
-			public static int ic_collapse = 2130837597;
+			public static int ic_dialog_close_dark = 2130837597;
 			
 			// aapt resource value: 0x7f02005e
-			public static int ic_collapse_00000 = 2130837598;
+			public static int ic_dialog_close_light = 2130837598;
 			
 			// aapt resource value: 0x7f02005f
-			public static int ic_collapse_00001 = 2130837599;
+			public static int ic_group_collapse_00 = 2130837599;
 			
 			// aapt resource value: 0x7f020060
-			public static int ic_collapse_00002 = 2130837600;
+			public static int ic_group_collapse_01 = 2130837600;
 			
 			// aapt resource value: 0x7f020061
-			public static int ic_collapse_00003 = 2130837601;
+			public static int ic_group_collapse_02 = 2130837601;
 			
 			// aapt resource value: 0x7f020062
-			public static int ic_collapse_00004 = 2130837602;
+			public static int ic_group_collapse_03 = 2130837602;
 			
 			// aapt resource value: 0x7f020063
-			public static int ic_collapse_00005 = 2130837603;
+			public static int ic_group_collapse_04 = 2130837603;
 			
 			// aapt resource value: 0x7f020064
-			public static int ic_collapse_00006 = 2130837604;
+			public static int ic_group_collapse_05 = 2130837604;
 			
 			// aapt resource value: 0x7f020065
-			public static int ic_collapse_00007 = 2130837605;
+			public static int ic_group_collapse_06 = 2130837605;
 			
 			// aapt resource value: 0x7f020066
-			public static int ic_collapse_00008 = 2130837606;
+			public static int ic_group_collapse_07 = 2130837606;
 			
 			// aapt resource value: 0x7f020067
-			public static int ic_collapse_00009 = 2130837607;
+			public static int ic_group_collapse_08 = 2130837607;
 			
 			// aapt resource value: 0x7f020068
-			public static int ic_collapse_00010 = 2130837608;
+			public static int ic_group_collapse_09 = 2130837608;
 			
 			// aapt resource value: 0x7f020069
-			public static int ic_collapse_00011 = 2130837609;
+			public static int ic_group_collapse_10 = 2130837609;
 			
 			// aapt resource value: 0x7f02006a
-			public static int ic_collapse_00012 = 2130837610;
+			public static int ic_group_collapse_11 = 2130837610;
 			
 			// aapt resource value: 0x7f02006b
-			public static int ic_collapse_00013 = 2130837611;
+			public static int ic_group_collapse_12 = 2130837611;
 			
 			// aapt resource value: 0x7f02006c
-			public static int ic_collapse_00014 = 2130837612;
+			public static int ic_group_collapse_13 = 2130837612;
 			
 			// aapt resource value: 0x7f02006d
-			public static int ic_collapse_00015 = 2130837613;
+			public static int ic_group_collapse_14 = 2130837613;
 			
 			// aapt resource value: 0x7f02006e
-			public static int ic_expand = 2130837614;
+			public static int ic_group_collapse_15 = 2130837614;
 			
 			// aapt resource value: 0x7f02006f
-			public static int ic_expand_00000 = 2130837615;
+			public static int ic_group_expand_00 = 2130837615;
 			
 			// aapt resource value: 0x7f020070
-			public static int ic_expand_00001 = 2130837616;
+			public static int ic_group_expand_01 = 2130837616;
 			
 			// aapt resource value: 0x7f020071
-			public static int ic_expand_00002 = 2130837617;
+			public static int ic_group_expand_02 = 2130837617;
 			
 			// aapt resource value: 0x7f020072
-			public static int ic_expand_00003 = 2130837618;
+			public static int ic_group_expand_03 = 2130837618;
 			
 			// aapt resource value: 0x7f020073
-			public static int ic_expand_00004 = 2130837619;
+			public static int ic_group_expand_04 = 2130837619;
 			
 			// aapt resource value: 0x7f020074
-			public static int ic_expand_00005 = 2130837620;
+			public static int ic_group_expand_05 = 2130837620;
 			
 			// aapt resource value: 0x7f020075
-			public static int ic_expand_00006 = 2130837621;
+			public static int ic_group_expand_06 = 2130837621;
 			
 			// aapt resource value: 0x7f020076
-			public static int ic_expand_00007 = 2130837622;
+			public static int ic_group_expand_07 = 2130837622;
 			
 			// aapt resource value: 0x7f020077
-			public static int ic_expand_00008 = 2130837623;
+			public static int ic_group_expand_08 = 2130837623;
 			
 			// aapt resource value: 0x7f020078
-			public static int ic_expand_00009 = 2130837624;
+			public static int ic_group_expand_09 = 2130837624;
 			
 			// aapt resource value: 0x7f020079
-			public static int ic_expand_00010 = 2130837625;
+			public static int ic_group_expand_10 = 2130837625;
 			
 			// aapt resource value: 0x7f02007a
-			public static int ic_expand_00011 = 2130837626;
+			public static int ic_group_expand_11 = 2130837626;
 			
 			// aapt resource value: 0x7f02007b
-			public static int ic_expand_00012 = 2130837627;
+			public static int ic_group_expand_12 = 2130837627;
 			
 			// aapt resource value: 0x7f02007c
-			public static int ic_expand_00013 = 2130837628;
+			public static int ic_group_expand_13 = 2130837628;
 			
 			// aapt resource value: 0x7f02007d
-			public static int ic_expand_00014 = 2130837629;
+			public static int ic_group_expand_14 = 2130837629;
 			
 			// aapt resource value: 0x7f02007e
-			public static int ic_expand_00015 = 2130837630;
+			public static int ic_group_expand_15 = 2130837630;
 			
 			// aapt resource value: 0x7f02007f
-			public static int ic_media_pause = 2130837631;
+			public static int ic_media_pause_dark = 2130837631;
 			
 			// aapt resource value: 0x7f020080
-			public static int ic_media_play = 2130837632;
+			public static int ic_media_pause_light = 2130837632;
 			
 			// aapt resource value: 0x7f020081
-			public static int ic_media_route_disabled_mono_dark = 2130837633;
+			public static int ic_media_play_dark = 2130837633;
 			
 			// aapt resource value: 0x7f020082
-			public static int ic_media_route_off_mono_dark = 2130837634;
+			public static int ic_media_play_light = 2130837634;
 			
 			// aapt resource value: 0x7f020083
-			public static int ic_media_route_on_0_mono_dark = 2130837635;
+			public static int ic_media_stop_dark = 2130837635;
 			
 			// aapt resource value: 0x7f020084
-			public static int ic_media_route_on_1_mono_dark = 2130837636;
+			public static int ic_media_stop_light = 2130837636;
 			
 			// aapt resource value: 0x7f020085
-			public static int ic_media_route_on_2_mono_dark = 2130837637;
+			public static int ic_mr_button_connected_00_dark = 2130837637;
 			
 			// aapt resource value: 0x7f020086
-			public static int ic_media_route_on_mono_dark = 2130837638;
+			public static int ic_mr_button_connected_00_light = 2130837638;
 			
 			// aapt resource value: 0x7f020087
-			public static int ic_pause_dark = 2130837639;
+			public static int ic_mr_button_connected_01_dark = 2130837639;
 			
 			// aapt resource value: 0x7f020088
-			public static int ic_pause_light = 2130837640;
+			public static int ic_mr_button_connected_01_light = 2130837640;
 			
 			// aapt resource value: 0x7f020089
-			public static int ic_play_dark = 2130837641;
+			public static int ic_mr_button_connected_02_dark = 2130837641;
 			
 			// aapt resource value: 0x7f02008a
-			public static int ic_play_light = 2130837642;
+			public static int ic_mr_button_connected_02_light = 2130837642;
 			
 			// aapt resource value: 0x7f02008b
-			public static int ic_speaker_dark = 2130837643;
+			public static int ic_mr_button_connected_03_dark = 2130837643;
 			
 			// aapt resource value: 0x7f02008c
-			public static int ic_speaker_group_dark = 2130837644;
+			public static int ic_mr_button_connected_03_light = 2130837644;
 			
 			// aapt resource value: 0x7f02008d
-			public static int ic_speaker_group_light = 2130837645;
+			public static int ic_mr_button_connected_04_dark = 2130837645;
 			
 			// aapt resource value: 0x7f02008e
-			public static int ic_speaker_light = 2130837646;
+			public static int ic_mr_button_connected_04_light = 2130837646;
 			
 			// aapt resource value: 0x7f02008f
-			public static int ic_tv_dark = 2130837647;
+			public static int ic_mr_button_connected_05_dark = 2130837647;
 			
 			// aapt resource value: 0x7f020090
-			public static int ic_tv_light = 2130837648;
+			public static int ic_mr_button_connected_05_light = 2130837648;
 			
 			// aapt resource value: 0x7f020091
-			public static int mr_dialog_material_background_dark = 2130837649;
+			public static int ic_mr_button_connected_06_dark = 2130837649;
 			
 			// aapt resource value: 0x7f020092
-			public static int mr_dialog_material_background_light = 2130837650;
+			public static int ic_mr_button_connected_06_light = 2130837650;
 			
 			// aapt resource value: 0x7f020093
-			public static int mr_ic_audiotrack_light = 2130837651;
+			public static int ic_mr_button_connected_07_dark = 2130837651;
 			
 			// aapt resource value: 0x7f020094
-			public static int mr_ic_cast_dark = 2130837652;
+			public static int ic_mr_button_connected_07_light = 2130837652;
 			
 			// aapt resource value: 0x7f020095
-			public static int mr_ic_cast_light = 2130837653;
+			public static int ic_mr_button_connected_08_dark = 2130837653;
 			
 			// aapt resource value: 0x7f020096
-			public static int mr_ic_close_dark = 2130837654;
+			public static int ic_mr_button_connected_08_light = 2130837654;
 			
 			// aapt resource value: 0x7f020097
-			public static int mr_ic_close_light = 2130837655;
+			public static int ic_mr_button_connected_09_dark = 2130837655;
 			
 			// aapt resource value: 0x7f020098
-			public static int mr_ic_media_route_connecting_mono_dark = 2130837656;
+			public static int ic_mr_button_connected_09_light = 2130837656;
 			
 			// aapt resource value: 0x7f020099
-			public static int mr_ic_media_route_connecting_mono_light = 2130837657;
+			public static int ic_mr_button_connected_10_dark = 2130837657;
 			
 			// aapt resource value: 0x7f02009a
-			public static int mr_ic_media_route_mono_dark = 2130837658;
+			public static int ic_mr_button_connected_10_light = 2130837658;
 			
 			// aapt resource value: 0x7f02009b
-			public static int mr_ic_media_route_mono_light = 2130837659;
+			public static int ic_mr_button_connected_11_dark = 2130837659;
 			
 			// aapt resource value: 0x7f02009c
-			public static int mr_ic_pause_dark = 2130837660;
+			public static int ic_mr_button_connected_11_light = 2130837660;
 			
 			// aapt resource value: 0x7f02009d
-			public static int mr_ic_pause_light = 2130837661;
+			public static int ic_mr_button_connected_12_dark = 2130837661;
 			
 			// aapt resource value: 0x7f02009e
-			public static int mr_ic_play_dark = 2130837662;
+			public static int ic_mr_button_connected_12_light = 2130837662;
 			
 			// aapt resource value: 0x7f02009f
-			public static int mr_ic_play_light = 2130837663;
+			public static int ic_mr_button_connected_13_dark = 2130837663;
 			
 			// aapt resource value: 0x7f0200a0
-			public static int notification_template_icon_bg = 2130837664;
+			public static int ic_mr_button_connected_13_light = 2130837664;
+			
+			// aapt resource value: 0x7f0200a1
+			public static int ic_mr_button_connected_14_dark = 2130837665;
+			
+			// aapt resource value: 0x7f0200a2
+			public static int ic_mr_button_connected_14_light = 2130837666;
+			
+			// aapt resource value: 0x7f0200a3
+			public static int ic_mr_button_connected_15_dark = 2130837667;
+			
+			// aapt resource value: 0x7f0200a4
+			public static int ic_mr_button_connected_15_light = 2130837668;
+			
+			// aapt resource value: 0x7f0200a5
+			public static int ic_mr_button_connected_16_dark = 2130837669;
+			
+			// aapt resource value: 0x7f0200a6
+			public static int ic_mr_button_connected_16_light = 2130837670;
+			
+			// aapt resource value: 0x7f0200a7
+			public static int ic_mr_button_connected_17_dark = 2130837671;
+			
+			// aapt resource value: 0x7f0200a8
+			public static int ic_mr_button_connected_17_light = 2130837672;
+			
+			// aapt resource value: 0x7f0200a9
+			public static int ic_mr_button_connected_18_dark = 2130837673;
+			
+			// aapt resource value: 0x7f0200aa
+			public static int ic_mr_button_connected_18_light = 2130837674;
+			
+			// aapt resource value: 0x7f0200ab
+			public static int ic_mr_button_connected_19_dark = 2130837675;
+			
+			// aapt resource value: 0x7f0200ac
+			public static int ic_mr_button_connected_19_light = 2130837676;
+			
+			// aapt resource value: 0x7f0200ad
+			public static int ic_mr_button_connected_20_dark = 2130837677;
+			
+			// aapt resource value: 0x7f0200ae
+			public static int ic_mr_button_connected_20_light = 2130837678;
+			
+			// aapt resource value: 0x7f0200af
+			public static int ic_mr_button_connected_21_dark = 2130837679;
+			
+			// aapt resource value: 0x7f0200b0
+			public static int ic_mr_button_connected_21_light = 2130837680;
+			
+			// aapt resource value: 0x7f0200b1
+			public static int ic_mr_button_connected_22_dark = 2130837681;
+			
+			// aapt resource value: 0x7f0200b2
+			public static int ic_mr_button_connected_22_light = 2130837682;
+			
+			// aapt resource value: 0x7f0200b3
+			public static int ic_mr_button_connected_23_dark = 2130837683;
+			
+			// aapt resource value: 0x7f0200b4
+			public static int ic_mr_button_connected_23_light = 2130837684;
+			
+			// aapt resource value: 0x7f0200b5
+			public static int ic_mr_button_connected_24_dark = 2130837685;
+			
+			// aapt resource value: 0x7f0200b6
+			public static int ic_mr_button_connected_24_light = 2130837686;
+			
+			// aapt resource value: 0x7f0200b7
+			public static int ic_mr_button_connected_25_dark = 2130837687;
+			
+			// aapt resource value: 0x7f0200b8
+			public static int ic_mr_button_connected_25_light = 2130837688;
+			
+			// aapt resource value: 0x7f0200b9
+			public static int ic_mr_button_connected_26_dark = 2130837689;
+			
+			// aapt resource value: 0x7f0200ba
+			public static int ic_mr_button_connected_26_light = 2130837690;
+			
+			// aapt resource value: 0x7f0200bb
+			public static int ic_mr_button_connected_27_dark = 2130837691;
+			
+			// aapt resource value: 0x7f0200bc
+			public static int ic_mr_button_connected_27_light = 2130837692;
+			
+			// aapt resource value: 0x7f0200bd
+			public static int ic_mr_button_connected_28_dark = 2130837693;
+			
+			// aapt resource value: 0x7f0200be
+			public static int ic_mr_button_connected_28_light = 2130837694;
+			
+			// aapt resource value: 0x7f0200bf
+			public static int ic_mr_button_connected_29_dark = 2130837695;
+			
+			// aapt resource value: 0x7f0200c0
+			public static int ic_mr_button_connected_29_light = 2130837696;
+			
+			// aapt resource value: 0x7f0200c1
+			public static int ic_mr_button_connected_30_dark = 2130837697;
+			
+			// aapt resource value: 0x7f0200c2
+			public static int ic_mr_button_connected_30_light = 2130837698;
+			
+			// aapt resource value: 0x7f0200c3
+			public static int ic_mr_button_connecting_00_dark = 2130837699;
+			
+			// aapt resource value: 0x7f0200c4
+			public static int ic_mr_button_connecting_00_light = 2130837700;
+			
+			// aapt resource value: 0x7f0200c5
+			public static int ic_mr_button_connecting_01_dark = 2130837701;
+			
+			// aapt resource value: 0x7f0200c6
+			public static int ic_mr_button_connecting_01_light = 2130837702;
+			
+			// aapt resource value: 0x7f0200c7
+			public static int ic_mr_button_connecting_02_dark = 2130837703;
+			
+			// aapt resource value: 0x7f0200c8
+			public static int ic_mr_button_connecting_02_light = 2130837704;
+			
+			// aapt resource value: 0x7f0200c9
+			public static int ic_mr_button_connecting_03_dark = 2130837705;
+			
+			// aapt resource value: 0x7f0200ca
+			public static int ic_mr_button_connecting_03_light = 2130837706;
+			
+			// aapt resource value: 0x7f0200cb
+			public static int ic_mr_button_connecting_04_dark = 2130837707;
+			
+			// aapt resource value: 0x7f0200cc
+			public static int ic_mr_button_connecting_04_light = 2130837708;
+			
+			// aapt resource value: 0x7f0200cd
+			public static int ic_mr_button_connecting_05_dark = 2130837709;
+			
+			// aapt resource value: 0x7f0200ce
+			public static int ic_mr_button_connecting_05_light = 2130837710;
+			
+			// aapt resource value: 0x7f0200cf
+			public static int ic_mr_button_connecting_06_dark = 2130837711;
+			
+			// aapt resource value: 0x7f0200d0
+			public static int ic_mr_button_connecting_06_light = 2130837712;
+			
+			// aapt resource value: 0x7f0200d1
+			public static int ic_mr_button_connecting_07_dark = 2130837713;
+			
+			// aapt resource value: 0x7f0200d2
+			public static int ic_mr_button_connecting_07_light = 2130837714;
+			
+			// aapt resource value: 0x7f0200d3
+			public static int ic_mr_button_connecting_08_dark = 2130837715;
+			
+			// aapt resource value: 0x7f0200d4
+			public static int ic_mr_button_connecting_08_light = 2130837716;
+			
+			// aapt resource value: 0x7f0200d5
+			public static int ic_mr_button_connecting_09_dark = 2130837717;
+			
+			// aapt resource value: 0x7f0200d6
+			public static int ic_mr_button_connecting_09_light = 2130837718;
+			
+			// aapt resource value: 0x7f0200d7
+			public static int ic_mr_button_connecting_10_dark = 2130837719;
+			
+			// aapt resource value: 0x7f0200d8
+			public static int ic_mr_button_connecting_10_light = 2130837720;
+			
+			// aapt resource value: 0x7f0200d9
+			public static int ic_mr_button_connecting_11_dark = 2130837721;
+			
+			// aapt resource value: 0x7f0200da
+			public static int ic_mr_button_connecting_11_light = 2130837722;
+			
+			// aapt resource value: 0x7f0200db
+			public static int ic_mr_button_connecting_12_dark = 2130837723;
+			
+			// aapt resource value: 0x7f0200dc
+			public static int ic_mr_button_connecting_12_light = 2130837724;
+			
+			// aapt resource value: 0x7f0200dd
+			public static int ic_mr_button_connecting_13_dark = 2130837725;
+			
+			// aapt resource value: 0x7f0200de
+			public static int ic_mr_button_connecting_13_light = 2130837726;
+			
+			// aapt resource value: 0x7f0200df
+			public static int ic_mr_button_connecting_14_dark = 2130837727;
+			
+			// aapt resource value: 0x7f0200e0
+			public static int ic_mr_button_connecting_14_light = 2130837728;
+			
+			// aapt resource value: 0x7f0200e1
+			public static int ic_mr_button_connecting_15_dark = 2130837729;
+			
+			// aapt resource value: 0x7f0200e2
+			public static int ic_mr_button_connecting_15_light = 2130837730;
+			
+			// aapt resource value: 0x7f0200e3
+			public static int ic_mr_button_connecting_16_dark = 2130837731;
+			
+			// aapt resource value: 0x7f0200e4
+			public static int ic_mr_button_connecting_16_light = 2130837732;
+			
+			// aapt resource value: 0x7f0200e5
+			public static int ic_mr_button_connecting_17_dark = 2130837733;
+			
+			// aapt resource value: 0x7f0200e6
+			public static int ic_mr_button_connecting_17_light = 2130837734;
+			
+			// aapt resource value: 0x7f0200e7
+			public static int ic_mr_button_connecting_18_dark = 2130837735;
+			
+			// aapt resource value: 0x7f0200e8
+			public static int ic_mr_button_connecting_18_light = 2130837736;
+			
+			// aapt resource value: 0x7f0200e9
+			public static int ic_mr_button_connecting_19_dark = 2130837737;
+			
+			// aapt resource value: 0x7f0200ea
+			public static int ic_mr_button_connecting_19_light = 2130837738;
+			
+			// aapt resource value: 0x7f0200eb
+			public static int ic_mr_button_connecting_20_dark = 2130837739;
+			
+			// aapt resource value: 0x7f0200ec
+			public static int ic_mr_button_connecting_20_light = 2130837740;
+			
+			// aapt resource value: 0x7f0200ed
+			public static int ic_mr_button_connecting_21_dark = 2130837741;
+			
+			// aapt resource value: 0x7f0200ee
+			public static int ic_mr_button_connecting_21_light = 2130837742;
+			
+			// aapt resource value: 0x7f0200ef
+			public static int ic_mr_button_connecting_22_dark = 2130837743;
+			
+			// aapt resource value: 0x7f0200f0
+			public static int ic_mr_button_connecting_22_light = 2130837744;
+			
+			// aapt resource value: 0x7f0200f1
+			public static int ic_mr_button_connecting_23_dark = 2130837745;
+			
+			// aapt resource value: 0x7f0200f2
+			public static int ic_mr_button_connecting_23_light = 2130837746;
+			
+			// aapt resource value: 0x7f0200f3
+			public static int ic_mr_button_connecting_24_dark = 2130837747;
+			
+			// aapt resource value: 0x7f0200f4
+			public static int ic_mr_button_connecting_24_light = 2130837748;
+			
+			// aapt resource value: 0x7f0200f5
+			public static int ic_mr_button_connecting_25_dark = 2130837749;
+			
+			// aapt resource value: 0x7f0200f6
+			public static int ic_mr_button_connecting_25_light = 2130837750;
+			
+			// aapt resource value: 0x7f0200f7
+			public static int ic_mr_button_connecting_26_dark = 2130837751;
+			
+			// aapt resource value: 0x7f0200f8
+			public static int ic_mr_button_connecting_26_light = 2130837752;
+			
+			// aapt resource value: 0x7f0200f9
+			public static int ic_mr_button_connecting_27_dark = 2130837753;
+			
+			// aapt resource value: 0x7f0200fa
+			public static int ic_mr_button_connecting_27_light = 2130837754;
+			
+			// aapt resource value: 0x7f0200fb
+			public static int ic_mr_button_connecting_28_dark = 2130837755;
+			
+			// aapt resource value: 0x7f0200fc
+			public static int ic_mr_button_connecting_28_light = 2130837756;
+			
+			// aapt resource value: 0x7f0200fd
+			public static int ic_mr_button_connecting_29_dark = 2130837757;
+			
+			// aapt resource value: 0x7f0200fe
+			public static int ic_mr_button_connecting_29_light = 2130837758;
+			
+			// aapt resource value: 0x7f0200ff
+			public static int ic_mr_button_connecting_30_dark = 2130837759;
+			
+			// aapt resource value: 0x7f020100
+			public static int ic_mr_button_connecting_30_light = 2130837760;
+			
+			// aapt resource value: 0x7f020101
+			public static int ic_mr_button_disabled_dark = 2130837761;
+			
+			// aapt resource value: 0x7f020102
+			public static int ic_mr_button_disabled_light = 2130837762;
+			
+			// aapt resource value: 0x7f020103
+			public static int ic_mr_button_disconnected_dark = 2130837763;
+			
+			// aapt resource value: 0x7f020104
+			public static int ic_mr_button_disconnected_light = 2130837764;
+			
+			// aapt resource value: 0x7f020105
+			public static int ic_mr_button_grey = 2130837765;
+			
+			// aapt resource value: 0x7f020106
+			public static int ic_vol_type_speaker_dark = 2130837766;
+			
+			// aapt resource value: 0x7f020107
+			public static int ic_vol_type_speaker_group_dark = 2130837767;
+			
+			// aapt resource value: 0x7f020108
+			public static int ic_vol_type_speaker_group_light = 2130837768;
+			
+			// aapt resource value: 0x7f020109
+			public static int ic_vol_type_speaker_light = 2130837769;
+			
+			// aapt resource value: 0x7f02010a
+			public static int ic_vol_type_tv_dark = 2130837770;
+			
+			// aapt resource value: 0x7f02010b
+			public static int ic_vol_type_tv_light = 2130837771;
+			
+			// aapt resource value: 0x7f02010c
+			public static int mr_button_connected_dark = 2130837772;
+			
+			// aapt resource value: 0x7f02010d
+			public static int mr_button_connected_light = 2130837773;
+			
+			// aapt resource value: 0x7f02010e
+			public static int mr_button_connecting_dark = 2130837774;
+			
+			// aapt resource value: 0x7f02010f
+			public static int mr_button_connecting_light = 2130837775;
+			
+			// aapt resource value: 0x7f020110
+			public static int mr_button_dark = 2130837776;
+			
+			// aapt resource value: 0x7f020111
+			public static int mr_button_light = 2130837777;
+			
+			// aapt resource value: 0x7f020112
+			public static int mr_dialog_close_dark = 2130837778;
+			
+			// aapt resource value: 0x7f020113
+			public static int mr_dialog_close_light = 2130837779;
+			
+			// aapt resource value: 0x7f020114
+			public static int mr_dialog_material_background_dark = 2130837780;
+			
+			// aapt resource value: 0x7f020115
+			public static int mr_dialog_material_background_light = 2130837781;
+			
+			// aapt resource value: 0x7f020116
+			public static int mr_group_collapse = 2130837782;
+			
+			// aapt resource value: 0x7f020117
+			public static int mr_group_expand = 2130837783;
+			
+			// aapt resource value: 0x7f020118
+			public static int mr_media_pause_dark = 2130837784;
+			
+			// aapt resource value: 0x7f020119
+			public static int mr_media_pause_light = 2130837785;
+			
+			// aapt resource value: 0x7f02011a
+			public static int mr_media_play_dark = 2130837786;
+			
+			// aapt resource value: 0x7f02011b
+			public static int mr_media_play_light = 2130837787;
+			
+			// aapt resource value: 0x7f02011c
+			public static int mr_media_stop_dark = 2130837788;
+			
+			// aapt resource value: 0x7f02011d
+			public static int mr_media_stop_light = 2130837789;
+			
+			// aapt resource value: 0x7f02011e
+			public static int mr_vol_type_audiotrack_dark = 2130837790;
+			
+			// aapt resource value: 0x7f02011f
+			public static int mr_vol_type_audiotrack_light = 2130837791;
+			
+			// aapt resource value: 0x7f020120
+			public static int navigation_empty_icon = 2130837792;
+			
+			// aapt resource value: 0x7f020121
+			public static int notification_action_background = 2130837793;
+			
+			// aapt resource value: 0x7f020122
+			public static int notification_bg = 2130837794;
+			
+			// aapt resource value: 0x7f020123
+			public static int notification_bg_low = 2130837795;
+			
+			// aapt resource value: 0x7f020124
+			public static int notification_bg_low_normal = 2130837796;
+			
+			// aapt resource value: 0x7f020125
+			public static int notification_bg_low_pressed = 2130837797;
+			
+			// aapt resource value: 0x7f020126
+			public static int notification_bg_normal = 2130837798;
+			
+			// aapt resource value: 0x7f020127
+			public static int notification_bg_normal_pressed = 2130837799;
+			
+			// aapt resource value: 0x7f020128
+			public static int notification_icon_background = 2130837800;
+			
+			// aapt resource value: 0x7f02012d
+			public static int notification_template_icon_bg = 2130837805;
+			
+			// aapt resource value: 0x7f02012e
+			public static int notification_template_icon_low_bg = 2130837806;
+			
+			// aapt resource value: 0x7f020129
+			public static int notification_tile_bg = 2130837801;
+			
+			// aapt resource value: 0x7f02012a
+			public static int notify_panel_notification_icon_bg = 2130837802;
+			
+			// aapt resource value: 0x7f02012b
+			public static int tooltip_frame_dark = 2130837803;
+			
+			// aapt resource value: 0x7f02012c
+			public static int tooltip_frame_light = 2130837804;
 			
 			static Drawable()
 			{
@@ -2208,461 +3013,608 @@ namespace SuaveControls.MaterialForms.Android
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f07008b
-			public static int action0 = 2131165323;
+			// aapt resource value: 0x7f080032
+			public static int ALT = 2131230770;
 			
-			// aapt resource value: 0x7f07005a
-			public static int action_bar = 2131165274;
+			// aapt resource value: 0x7f080033
+			public static int CTRL = 2131230771;
 			
-			// aapt resource value: 0x7f070001
-			public static int action_bar_activity_content = 2131165185;
+			// aapt resource value: 0x7f080034
+			public static int FUNCTION = 2131230772;
 			
-			// aapt resource value: 0x7f070059
-			public static int action_bar_container = 2131165273;
+			// aapt resource value: 0x7f080035
+			public static int META = 2131230773;
 			
-			// aapt resource value: 0x7f070055
-			public static int action_bar_root = 2131165269;
+			// aapt resource value: 0x7f080036
+			public static int SHIFT = 2131230774;
 			
-			// aapt resource value: 0x7f070002
-			public static int action_bar_spinner = 2131165186;
+			// aapt resource value: 0x7f080037
+			public static int SYM = 2131230775;
 			
-			// aapt resource value: 0x7f07003b
-			public static int action_bar_subtitle = 2131165243;
+			// aapt resource value: 0x7f0800b6
+			public static int action0 = 2131230902;
 			
-			// aapt resource value: 0x7f07003a
-			public static int action_bar_title = 2131165242;
+			// aapt resource value: 0x7f08007c
+			public static int action_bar = 2131230844;
 			
-			// aapt resource value: 0x7f07005b
-			public static int action_context_bar = 2131165275;
+			// aapt resource value: 0x7f080001
+			public static int action_bar_activity_content = 2131230721;
 			
-			// aapt resource value: 0x7f07008f
-			public static int action_divider = 2131165327;
+			// aapt resource value: 0x7f08007b
+			public static int action_bar_container = 2131230843;
 			
-			// aapt resource value: 0x7f070003
-			public static int action_menu_divider = 2131165187;
+			// aapt resource value: 0x7f080077
+			public static int action_bar_root = 2131230839;
 			
-			// aapt resource value: 0x7f070004
-			public static int action_menu_presenter = 2131165188;
+			// aapt resource value: 0x7f080002
+			public static int action_bar_spinner = 2131230722;
 			
-			// aapt resource value: 0x7f070057
-			public static int action_mode_bar = 2131165271;
+			// aapt resource value: 0x7f08005b
+			public static int action_bar_subtitle = 2131230811;
 			
-			// aapt resource value: 0x7f070056
-			public static int action_mode_bar_stub = 2131165270;
+			// aapt resource value: 0x7f08005a
+			public static int action_bar_title = 2131230810;
 			
-			// aapt resource value: 0x7f07003c
-			public static int action_mode_close_button = 2131165244;
+			// aapt resource value: 0x7f0800b3
+			public static int action_container = 2131230899;
 			
-			// aapt resource value: 0x7f07003d
-			public static int activity_chooser_view_content = 2131165245;
+			// aapt resource value: 0x7f08007d
+			public static int action_context_bar = 2131230845;
 			
-			// aapt resource value: 0x7f070049
-			public static int alertTitle = 2131165257;
+			// aapt resource value: 0x7f0800ba
+			public static int action_divider = 2131230906;
 			
-			// aapt resource value: 0x7f07001e
-			public static int always = 2131165214;
+			// aapt resource value: 0x7f0800b4
+			public static int action_image = 2131230900;
 			
-			// aapt resource value: 0x7f07001b
-			public static int beginning = 2131165211;
+			// aapt resource value: 0x7f080003
+			public static int action_menu_divider = 2131230723;
 			
-			// aapt resource value: 0x7f07002a
-			public static int bottom = 2131165226;
+			// aapt resource value: 0x7f080004
+			public static int action_menu_presenter = 2131230724;
 			
-			// aapt resource value: 0x7f070044
-			public static int buttonPanel = 2131165252;
+			// aapt resource value: 0x7f080079
+			public static int action_mode_bar = 2131230841;
 			
-			// aapt resource value: 0x7f07008c
-			public static int cancel_action = 2131165324;
+			// aapt resource value: 0x7f080078
+			public static int action_mode_bar_stub = 2131230840;
 			
-			// aapt resource value: 0x7f07002b
-			public static int center = 2131165227;
+			// aapt resource value: 0x7f08005c
+			public static int action_mode_close_button = 2131230812;
 			
-			// aapt resource value: 0x7f07002c
-			public static int center_horizontal = 2131165228;
+			// aapt resource value: 0x7f0800b5
+			public static int action_text = 2131230901;
 			
-			// aapt resource value: 0x7f07002d
-			public static int center_vertical = 2131165229;
+			// aapt resource value: 0x7f0800c3
+			public static int actions = 2131230915;
 			
-			// aapt resource value: 0x7f070052
-			public static int checkbox = 2131165266;
+			// aapt resource value: 0x7f08005d
+			public static int activity_chooser_view_content = 2131230813;
 			
-			// aapt resource value: 0x7f070092
-			public static int chronometer = 2131165330;
+			// aapt resource value: 0x7f080027
+			public static int add = 2131230759;
 			
-			// aapt resource value: 0x7f070033
-			public static int clip_horizontal = 2131165235;
+			// aapt resource value: 0x7f080070
+			public static int alertTitle = 2131230832;
 			
-			// aapt resource value: 0x7f070034
-			public static int clip_vertical = 2131165236;
+			// aapt resource value: 0x7f080052
+			public static int all = 2131230802;
 			
-			// aapt resource value: 0x7f07001f
-			public static int collapseActionView = 2131165215;
+			// aapt resource value: 0x7f080038
+			public static int always = 2131230776;
 			
-			// aapt resource value: 0x7f07004a
-			public static int contentPanel = 2131165258;
+			// aapt resource value: 0x7f080056
+			public static int async = 2131230806;
 			
-			// aapt resource value: 0x7f070050
-			public static int custom = 2131165264;
+			// aapt resource value: 0x7f080044
+			public static int auto = 2131230788;
 			
-			// aapt resource value: 0x7f07004f
-			public static int customPanel = 2131165263;
+			// aapt resource value: 0x7f08002f
+			public static int beginning = 2131230767;
 			
-			// aapt resource value: 0x7f070058
-			public static int decor_content_parent = 2131165272;
+			// aapt resource value: 0x7f080057
+			public static int blocking = 2131230807;
 			
-			// aapt resource value: 0x7f070040
-			public static int default_activity_button = 2131165248;
+			// aapt resource value: 0x7f08003d
+			public static int bottom = 2131230781;
 			
-			// aapt resource value: 0x7f07006a
-			public static int design_bottom_sheet = 2131165290;
+			// aapt resource value: 0x7f080063
+			public static int buttonPanel = 2131230819;
 			
-			// aapt resource value: 0x7f070071
-			public static int design_menu_item_action_area = 2131165297;
+			// aapt resource value: 0x7f0800b7
+			public static int cancel_action = 2131230903;
 			
-			// aapt resource value: 0x7f070070
-			public static int design_menu_item_action_area_stub = 2131165296;
+			// aapt resource value: 0x7f080045
+			public static int center = 2131230789;
 			
-			// aapt resource value: 0x7f07006f
-			public static int design_menu_item_text = 2131165295;
+			// aapt resource value: 0x7f080046
+			public static int center_horizontal = 2131230790;
 			
-			// aapt resource value: 0x7f07006e
-			public static int design_navigation_view = 2131165294;
+			// aapt resource value: 0x7f080047
+			public static int center_vertical = 2131230791;
 			
-			// aapt resource value: 0x7f07000e
-			public static int disableHome = 2131165198;
+			// aapt resource value: 0x7f080073
+			public static int checkbox = 2131230835;
 			
-			// aapt resource value: 0x7f07005c
-			public static int edit_query = 2131165276;
+			// aapt resource value: 0x7f0800bf
+			public static int chronometer = 2131230911;
 			
-			// aapt resource value: 0x7f07001c
-			public static int end = 2131165212;
+			// aapt resource value: 0x7f08004e
+			public static int clip_horizontal = 2131230798;
 			
-			// aapt resource value: 0x7f070097
-			public static int end_padder = 2131165335;
+			// aapt resource value: 0x7f08004f
+			public static int clip_vertical = 2131230799;
 			
-			// aapt resource value: 0x7f070023
-			public static int enterAlways = 2131165219;
+			// aapt resource value: 0x7f080039
+			public static int collapseActionView = 2131230777;
 			
-			// aapt resource value: 0x7f070024
-			public static int enterAlwaysCollapsed = 2131165220;
+			// aapt resource value: 0x7f08008d
+			public static int container = 2131230861;
 			
-			// aapt resource value: 0x7f070025
-			public static int exitUntilCollapsed = 2131165221;
+			// aapt resource value: 0x7f080066
+			public static int contentPanel = 2131230822;
 			
-			// aapt resource value: 0x7f07003e
-			public static int expand_activities_button = 2131165246;
+			// aapt resource value: 0x7f08008e
+			public static int coordinator = 2131230862;
 			
-			// aapt resource value: 0x7f070051
-			public static int expanded_menu = 2131165265;
+			// aapt resource value: 0x7f08006d
+			public static int custom = 2131230829;
 			
-			// aapt resource value: 0x7f070035
-			public static int fill = 2131165237;
+			// aapt resource value: 0x7f08006c
+			public static int customPanel = 2131230828;
 			
-			// aapt resource value: 0x7f070036
-			public static int fill_horizontal = 2131165238;
+			// aapt resource value: 0x7f08007a
+			public static int decor_content_parent = 2131230842;
 			
-			// aapt resource value: 0x7f07002e
-			public static int fill_vertical = 2131165230;
+			// aapt resource value: 0x7f080060
+			public static int default_activity_button = 2131230816;
 			
-			// aapt resource value: 0x7f070038
-			public static int @fixed = 2131165240;
+			// aapt resource value: 0x7f080090
+			public static int design_bottom_sheet = 2131230864;
 			
-			// aapt resource value: 0x7f070005
-			public static int home = 2131165189;
+			// aapt resource value: 0x7f080097
+			public static int design_menu_item_action_area = 2131230871;
 			
-			// aapt resource value: 0x7f07000f
-			public static int homeAsUp = 2131165199;
+			// aapt resource value: 0x7f080096
+			public static int design_menu_item_action_area_stub = 2131230870;
 			
-			// aapt resource value: 0x7f070042
-			public static int icon = 2131165250;
+			// aapt resource value: 0x7f080095
+			public static int design_menu_item_text = 2131230869;
 			
-			// aapt resource value: 0x7f070020
-			public static int ifRoom = 2131165216;
+			// aapt resource value: 0x7f080094
+			public static int design_navigation_view = 2131230868;
 			
-			// aapt resource value: 0x7f07003f
-			public static int image = 2131165247;
+			// aapt resource value: 0x7f080020
+			public static int disableHome = 2131230752;
 			
-			// aapt resource value: 0x7f070096
-			public static int info = 2131165334;
+			// aapt resource value: 0x7f08007e
+			public static int edit_query = 2131230846;
 			
-			// aapt resource value: 0x7f070000
-			public static int item_touch_helper_previous_elevation = 2131165184;
+			// aapt resource value: 0x7f080030
+			public static int end = 2131230768;
 			
-			// aapt resource value: 0x7f07002f
-			public static int left = 2131165231;
+			// aapt resource value: 0x7f0800c5
+			public static int end_padder = 2131230917;
 			
-			// aapt resource value: 0x7f070090
-			public static int line1 = 2131165328;
+			// aapt resource value: 0x7f08003f
+			public static int enterAlways = 2131230783;
 			
-			// aapt resource value: 0x7f070094
-			public static int line3 = 2131165332;
+			// aapt resource value: 0x7f080040
+			public static int enterAlwaysCollapsed = 2131230784;
 			
-			// aapt resource value: 0x7f07000b
-			public static int listMode = 2131165195;
+			// aapt resource value: 0x7f080041
+			public static int exitUntilCollapsed = 2131230785;
 			
-			// aapt resource value: 0x7f070041
-			public static int list_item = 2131165249;
+			// aapt resource value: 0x7f08005e
+			public static int expand_activities_button = 2131230814;
 			
-			// aapt resource value: 0x7f07008e
-			public static int media_actions = 2131165326;
+			// aapt resource value: 0x7f080072
+			public static int expanded_menu = 2131230834;
 			
-			// aapt resource value: 0x7f07001d
-			public static int middle = 2131165213;
+			// aapt resource value: 0x7f080050
+			public static int fill = 2131230800;
 			
-			// aapt resource value: 0x7f070037
-			public static int mini = 2131165239;
+			// aapt resource value: 0x7f080051
+			public static int fill_horizontal = 2131230801;
 			
-			// aapt resource value: 0x7f07007d
-			public static int mr_art = 2131165309;
+			// aapt resource value: 0x7f080048
+			public static int fill_vertical = 2131230792;
 			
-			// aapt resource value: 0x7f070072
-			public static int mr_chooser_list = 2131165298;
+			// aapt resource value: 0x7f080054
+			public static int @fixed = 2131230804;
 			
-			// aapt resource value: 0x7f070075
-			public static int mr_chooser_route_desc = 2131165301;
+			// aapt resource value: 0x7f080058
+			public static int forever = 2131230808;
 			
-			// aapt resource value: 0x7f070073
-			public static int mr_chooser_route_icon = 2131165299;
+			// aapt resource value: 0x7f08000a
+			public static int ghost_view = 2131230730;
 			
-			// aapt resource value: 0x7f070074
-			public static int mr_chooser_route_name = 2131165300;
+			// aapt resource value: 0x7f080005
+			public static int home = 2131230725;
 			
-			// aapt resource value: 0x7f07007a
-			public static int mr_close = 2131165306;
+			// aapt resource value: 0x7f080021
+			public static int homeAsUp = 2131230753;
 			
-			// aapt resource value: 0x7f070080
-			public static int mr_control_divider = 2131165312;
+			// aapt resource value: 0x7f080062
+			public static int icon = 2131230818;
 			
-			// aapt resource value: 0x7f070086
-			public static int mr_control_play_pause = 2131165318;
+			// aapt resource value: 0x7f0800c4
+			public static int icon_group = 2131230916;
 			
-			// aapt resource value: 0x7f070089
-			public static int mr_control_subtitle = 2131165321;
+			// aapt resource value: 0x7f08003a
+			public static int ifRoom = 2131230778;
 			
-			// aapt resource value: 0x7f070088
-			public static int mr_control_title = 2131165320;
+			// aapt resource value: 0x7f08005f
+			public static int image = 2131230815;
 			
-			// aapt resource value: 0x7f070087
-			public static int mr_control_title_container = 2131165319;
+			// aapt resource value: 0x7f0800c0
+			public static int info = 2131230912;
 			
-			// aapt resource value: 0x7f07007b
-			public static int mr_custom_control = 2131165307;
+			// aapt resource value: 0x7f080059
+			public static int italic = 2131230809;
 			
-			// aapt resource value: 0x7f07007c
-			public static int mr_default_control = 2131165308;
+			// aapt resource value: 0x7f080000
+			public static int item_touch_helper_previous_elevation = 2131230720;
 			
-			// aapt resource value: 0x7f070077
-			public static int mr_dialog_area = 2131165303;
+			// aapt resource value: 0x7f08008c
+			public static int largeLabel = 2131230860;
 			
-			// aapt resource value: 0x7f070076
-			public static int mr_expandable_area = 2131165302;
+			// aapt resource value: 0x7f080049
+			public static int left = 2131230793;
 			
-			// aapt resource value: 0x7f07008a
-			public static int mr_group_expand_collapse = 2131165322;
+			// aapt resource value: 0x7f080017
+			public static int line1 = 2131230743;
 			
-			// aapt resource value: 0x7f07007e
-			public static int mr_media_main_control = 2131165310;
+			// aapt resource value: 0x7f080018
+			public static int line3 = 2131230744;
 			
-			// aapt resource value: 0x7f070079
-			public static int mr_name = 2131165305;
+			// aapt resource value: 0x7f08001d
+			public static int listMode = 2131230749;
 			
-			// aapt resource value: 0x7f07007f
-			public static int mr_playback_control = 2131165311;
+			// aapt resource value: 0x7f080061
+			public static int list_item = 2131230817;
 			
-			// aapt resource value: 0x7f070078
-			public static int mr_title_bar = 2131165304;
+			// aapt resource value: 0x7f0800c8
+			public static int masked = 2131230920;
 			
-			// aapt resource value: 0x7f070081
-			public static int mr_volume_control = 2131165313;
+			// aapt resource value: 0x7f0800b9
+			public static int media_actions = 2131230905;
 			
-			// aapt resource value: 0x7f070082
-			public static int mr_volume_group_list = 2131165314;
+			// aapt resource value: 0x7f0800c6
+			public static int message = 2131230918;
 			
-			// aapt resource value: 0x7f070084
-			public static int mr_volume_item_icon = 2131165316;
+			// aapt resource value: 0x7f080031
+			public static int middle = 2131230769;
 			
-			// aapt resource value: 0x7f070085
-			public static int mr_volume_slider = 2131165317;
+			// aapt resource value: 0x7f080053
+			public static int mini = 2131230803;
 			
-			// aapt resource value: 0x7f070016
-			public static int multiply = 2131165206;
+			// aapt resource value: 0x7f0800a5
+			public static int mr_art = 2131230885;
 			
-			// aapt resource value: 0x7f07006d
-			public static int navigation_header_container = 2131165293;
+			// aapt resource value: 0x7f08009a
+			public static int mr_chooser_list = 2131230874;
 			
-			// aapt resource value: 0x7f070021
-			public static int never = 2131165217;
+			// aapt resource value: 0x7f08009d
+			public static int mr_chooser_route_desc = 2131230877;
 			
-			// aapt resource value: 0x7f070010
-			public static int none = 2131165200;
+			// aapt resource value: 0x7f08009b
+			public static int mr_chooser_route_icon = 2131230875;
 			
-			// aapt resource value: 0x7f07000c
-			public static int normal = 2131165196;
+			// aapt resource value: 0x7f08009c
+			public static int mr_chooser_route_name = 2131230876;
 			
-			// aapt resource value: 0x7f070028
-			public static int parallax = 2131165224;
+			// aapt resource value: 0x7f080099
+			public static int mr_chooser_title = 2131230873;
 			
-			// aapt resource value: 0x7f070046
-			public static int parentPanel = 2131165254;
+			// aapt resource value: 0x7f0800a2
+			public static int mr_close = 2131230882;
 			
-			// aapt resource value: 0x7f070029
-			public static int pin = 2131165225;
+			// aapt resource value: 0x7f0800a8
+			public static int mr_control_divider = 2131230888;
 			
-			// aapt resource value: 0x7f070006
-			public static int progress_circular = 2131165190;
+			// aapt resource value: 0x7f0800ae
+			public static int mr_control_playback_ctrl = 2131230894;
 			
-			// aapt resource value: 0x7f070007
-			public static int progress_horizontal = 2131165191;
+			// aapt resource value: 0x7f0800b1
+			public static int mr_control_subtitle = 2131230897;
 			
-			// aapt resource value: 0x7f070054
-			public static int radio = 2131165268;
+			// aapt resource value: 0x7f0800b0
+			public static int mr_control_title = 2131230896;
 			
-			// aapt resource value: 0x7f070030
-			public static int right = 2131165232;
+			// aapt resource value: 0x7f0800af
+			public static int mr_control_title_container = 2131230895;
 			
-			// aapt resource value: 0x7f070017
-			public static int screen = 2131165207;
+			// aapt resource value: 0x7f0800a3
+			public static int mr_custom_control = 2131230883;
 			
-			// aapt resource value: 0x7f070026
-			public static int scroll = 2131165222;
+			// aapt resource value: 0x7f0800a4
+			public static int mr_default_control = 2131230884;
 			
-			// aapt resource value: 0x7f07004e
-			public static int scrollIndicatorDown = 2131165262;
+			// aapt resource value: 0x7f08009f
+			public static int mr_dialog_area = 2131230879;
 			
-			// aapt resource value: 0x7f07004b
-			public static int scrollIndicatorUp = 2131165259;
+			// aapt resource value: 0x7f08009e
+			public static int mr_expandable_area = 2131230878;
 			
-			// aapt resource value: 0x7f07004c
-			public static int scrollView = 2131165260;
+			// aapt resource value: 0x7f0800b2
+			public static int mr_group_expand_collapse = 2131230898;
 			
-			// aapt resource value: 0x7f070039
-			public static int scrollable = 2131165241;
+			// aapt resource value: 0x7f0800a6
+			public static int mr_media_main_control = 2131230886;
 			
-			// aapt resource value: 0x7f07005e
-			public static int search_badge = 2131165278;
+			// aapt resource value: 0x7f0800a1
+			public static int mr_name = 2131230881;
 			
-			// aapt resource value: 0x7f07005d
-			public static int search_bar = 2131165277;
+			// aapt resource value: 0x7f0800a7
+			public static int mr_playback_control = 2131230887;
 			
-			// aapt resource value: 0x7f07005f
-			public static int search_button = 2131165279;
+			// aapt resource value: 0x7f0800a0
+			public static int mr_title_bar = 2131230880;
 			
-			// aapt resource value: 0x7f070064
-			public static int search_close_btn = 2131165284;
+			// aapt resource value: 0x7f0800a9
+			public static int mr_volume_control = 2131230889;
 			
-			// aapt resource value: 0x7f070060
-			public static int search_edit_frame = 2131165280;
+			// aapt resource value: 0x7f0800aa
+			public static int mr_volume_group_list = 2131230890;
 			
-			// aapt resource value: 0x7f070066
-			public static int search_go_btn = 2131165286;
+			// aapt resource value: 0x7f0800ac
+			public static int mr_volume_item_icon = 2131230892;
 			
-			// aapt resource value: 0x7f070061
-			public static int search_mag_icon = 2131165281;
+			// aapt resource value: 0x7f0800ad
+			public static int mr_volume_slider = 2131230893;
 			
-			// aapt resource value: 0x7f070062
-			public static int search_plate = 2131165282;
+			// aapt resource value: 0x7f080028
+			public static int multiply = 2131230760;
 			
-			// aapt resource value: 0x7f070063
-			public static int search_src_text = 2131165283;
+			// aapt resource value: 0x7f080093
+			public static int navigation_header_container = 2131230867;
 			
-			// aapt resource value: 0x7f070067
-			public static int search_voice_btn = 2131165287;
+			// aapt resource value: 0x7f08003b
+			public static int never = 2131230779;
 			
-			// aapt resource value: 0x7f070068
-			public static int select_dialog_listview = 2131165288;
+			// aapt resource value: 0x7f080022
+			public static int none = 2131230754;
 			
-			// aapt resource value: 0x7f070053
-			public static int shortcut = 2131165267;
+			// aapt resource value: 0x7f08001e
+			public static int normal = 2131230750;
 			
-			// aapt resource value: 0x7f070011
-			public static int showCustom = 2131165201;
+			// aapt resource value: 0x7f0800c2
+			public static int notification_background = 2131230914;
 			
-			// aapt resource value: 0x7f070012
-			public static int showHome = 2131165202;
+			// aapt resource value: 0x7f0800bc
+			public static int notification_main_column = 2131230908;
 			
-			// aapt resource value: 0x7f070013
-			public static int showTitle = 2131165203;
+			// aapt resource value: 0x7f0800bb
+			public static int notification_main_column_container = 2131230907;
 			
-			// aapt resource value: 0x7f07006c
-			public static int snackbar_action = 2131165292;
+			// aapt resource value: 0x7f08004c
+			public static int parallax = 2131230796;
 			
-			// aapt resource value: 0x7f07006b
-			public static int snackbar_text = 2131165291;
+			// aapt resource value: 0x7f080065
+			public static int parentPanel = 2131230821;
 			
-			// aapt resource value: 0x7f070027
-			public static int snap = 2131165223;
+			// aapt resource value: 0x7f08000b
+			public static int parent_matrix = 2131230731;
 			
-			// aapt resource value: 0x7f070045
-			public static int spacer = 2131165253;
+			// aapt resource value: 0x7f08004d
+			public static int pin = 2131230797;
 			
-			// aapt resource value: 0x7f070008
-			public static int split_action_bar = 2131165192;
+			// aapt resource value: 0x7f080006
+			public static int progress_circular = 2131230726;
 			
-			// aapt resource value: 0x7f070018
-			public static int src_atop = 2131165208;
+			// aapt resource value: 0x7f080007
+			public static int progress_horizontal = 2131230727;
 			
-			// aapt resource value: 0x7f070019
-			public static int src_in = 2131165209;
+			// aapt resource value: 0x7f080075
+			public static int radio = 2131230837;
 			
-			// aapt resource value: 0x7f07001a
-			public static int src_over = 2131165210;
+			// aapt resource value: 0x7f08004a
+			public static int right = 2131230794;
 			
-			// aapt resource value: 0x7f070031
-			public static int start = 2131165233;
+			// aapt resource value: 0x7f0800c1
+			public static int right_icon = 2131230913;
 			
-			// aapt resource value: 0x7f07008d
-			public static int status_bar_latest_event_content = 2131165325;
+			// aapt resource value: 0x7f0800bd
+			public static int right_side = 2131230909;
 			
-			// aapt resource value: 0x7f070065
-			public static int submit_area = 2131165285;
+			// aapt resource value: 0x7f08000c
+			public static int save_image_matrix = 2131230732;
 			
-			// aapt resource value: 0x7f07000d
-			public static int tabMode = 2131165197;
+			// aapt resource value: 0x7f08000d
+			public static int save_non_transition_alpha = 2131230733;
 			
-			// aapt resource value: 0x7f070095
-			public static int text = 2131165333;
+			// aapt resource value: 0x7f08000e
+			public static int save_scale_type = 2131230734;
 			
-			// aapt resource value: 0x7f070093
-			public static int text2 = 2131165331;
+			// aapt resource value: 0x7f080029
+			public static int screen = 2131230761;
 			
-			// aapt resource value: 0x7f07004d
-			public static int textSpacerNoButtons = 2131165261;
+			// aapt resource value: 0x7f080042
+			public static int scroll = 2131230786;
 			
-			// aapt resource value: 0x7f070091
-			public static int time = 2131165329;
+			// aapt resource value: 0x7f08006b
+			public static int scrollIndicatorDown = 2131230827;
 			
-			// aapt resource value: 0x7f070043
-			public static int title = 2131165251;
+			// aapt resource value: 0x7f080067
+			public static int scrollIndicatorUp = 2131230823;
 			
-			// aapt resource value: 0x7f070048
-			public static int title_template = 2131165256;
+			// aapt resource value: 0x7f080068
+			public static int scrollView = 2131230824;
 			
-			// aapt resource value: 0x7f070032
-			public static int top = 2131165234;
+			// aapt resource value: 0x7f080055
+			public static int scrollable = 2131230805;
 			
-			// aapt resource value: 0x7f070047
-			public static int topPanel = 2131165255;
+			// aapt resource value: 0x7f080080
+			public static int search_badge = 2131230848;
 			
-			// aapt resource value: 0x7f070069
-			public static int touch_outside = 2131165289;
+			// aapt resource value: 0x7f08007f
+			public static int search_bar = 2131230847;
 			
-			// aapt resource value: 0x7f070009
-			public static int up = 2131165193;
+			// aapt resource value: 0x7f080081
+			public static int search_button = 2131230849;
 			
-			// aapt resource value: 0x7f070014
-			public static int useLogo = 2131165204;
+			// aapt resource value: 0x7f080086
+			public static int search_close_btn = 2131230854;
 			
-			// aapt resource value: 0x7f07000a
-			public static int view_offset_helper = 2131165194;
+			// aapt resource value: 0x7f080082
+			public static int search_edit_frame = 2131230850;
 			
-			// aapt resource value: 0x7f070083
-			public static int volume_item_container = 2131165315;
+			// aapt resource value: 0x7f080088
+			public static int search_go_btn = 2131230856;
 			
-			// aapt resource value: 0x7f070022
-			public static int withText = 2131165218;
+			// aapt resource value: 0x7f080083
+			public static int search_mag_icon = 2131230851;
 			
-			// aapt resource value: 0x7f070015
-			public static int wrap_content = 2131165205;
+			// aapt resource value: 0x7f080084
+			public static int search_plate = 2131230852;
+			
+			// aapt resource value: 0x7f080085
+			public static int search_src_text = 2131230853;
+			
+			// aapt resource value: 0x7f080089
+			public static int search_voice_btn = 2131230857;
+			
+			// aapt resource value: 0x7f08008a
+			public static int select_dialog_listview = 2131230858;
+			
+			// aapt resource value: 0x7f080074
+			public static int shortcut = 2131230836;
+			
+			// aapt resource value: 0x7f080023
+			public static int showCustom = 2131230755;
+			
+			// aapt resource value: 0x7f080024
+			public static int showHome = 2131230756;
+			
+			// aapt resource value: 0x7f080025
+			public static int showTitle = 2131230757;
+			
+			// aapt resource value: 0x7f08008b
+			public static int smallLabel = 2131230859;
+			
+			// aapt resource value: 0x7f080092
+			public static int snackbar_action = 2131230866;
+			
+			// aapt resource value: 0x7f080091
+			public static int snackbar_text = 2131230865;
+			
+			// aapt resource value: 0x7f080043
+			public static int snap = 2131230787;
+			
+			// aapt resource value: 0x7f080064
+			public static int spacer = 2131230820;
+			
+			// aapt resource value: 0x7f080008
+			public static int split_action_bar = 2131230728;
+			
+			// aapt resource value: 0x7f08002a
+			public static int src_atop = 2131230762;
+			
+			// aapt resource value: 0x7f08002b
+			public static int src_in = 2131230763;
+			
+			// aapt resource value: 0x7f08002c
+			public static int src_over = 2131230764;
+			
+			// aapt resource value: 0x7f08004b
+			public static int start = 2131230795;
+			
+			// aapt resource value: 0x7f0800b8
+			public static int status_bar_latest_event_content = 2131230904;
+			
+			// aapt resource value: 0x7f080076
+			public static int submenuarrow = 2131230838;
+			
+			// aapt resource value: 0x7f080087
+			public static int submit_area = 2131230855;
+			
+			// aapt resource value: 0x7f08001f
+			public static int tabMode = 2131230751;
+			
+			// aapt resource value: 0x7f080019
+			public static int tag_transition_group = 2131230745;
+			
+			// aapt resource value: 0x7f08001a
+			public static int text = 2131230746;
+			
+			// aapt resource value: 0x7f08001b
+			public static int text2 = 2131230747;
+			
+			// aapt resource value: 0x7f08006a
+			public static int textSpacerNoButtons = 2131230826;
+			
+			// aapt resource value: 0x7f080069
+			public static int textSpacerNoTitle = 2131230825;
+			
+			// aapt resource value: 0x7f080098
+			public static int text_input_password_toggle = 2131230872;
+			
+			// aapt resource value: 0x7f080014
+			public static int textinput_counter = 2131230740;
+			
+			// aapt resource value: 0x7f080015
+			public static int textinput_error = 2131230741;
+			
+			// aapt resource value: 0x7f0800be
+			public static int time = 2131230910;
+			
+			// aapt resource value: 0x7f08001c
+			public static int title = 2131230748;
+			
+			// aapt resource value: 0x7f080071
+			public static int titleDividerNoCustom = 2131230833;
+			
+			// aapt resource value: 0x7f08006f
+			public static int title_template = 2131230831;
+			
+			// aapt resource value: 0x7f08003e
+			public static int top = 2131230782;
+			
+			// aapt resource value: 0x7f08006e
+			public static int topPanel = 2131230830;
+			
+			// aapt resource value: 0x7f08008f
+			public static int touch_outside = 2131230863;
+			
+			// aapt resource value: 0x7f08000f
+			public static int transition_current_scene = 2131230735;
+			
+			// aapt resource value: 0x7f080010
+			public static int transition_layout_save = 2131230736;
+			
+			// aapt resource value: 0x7f080011
+			public static int transition_position = 2131230737;
+			
+			// aapt resource value: 0x7f080012
+			public static int transition_scene_layoutid_cache = 2131230738;
+			
+			// aapt resource value: 0x7f080013
+			public static int transition_transform = 2131230739;
+			
+			// aapt resource value: 0x7f08002d
+			public static int uniform = 2131230765;
+			
+			// aapt resource value: 0x7f080009
+			public static int up = 2131230729;
+			
+			// aapt resource value: 0x7f080026
+			public static int useLogo = 2131230758;
+			
+			// aapt resource value: 0x7f080016
+			public static int view_offset_helper = 2131230742;
+			
+			// aapt resource value: 0x7f0800c7
+			public static int visible = 2131230919;
+			
+			// aapt resource value: 0x7f0800ab
+			public static int volume_item_container = 2131230891;
+			
+			// aapt resource value: 0x7f08003c
+			public static int withText = 2131230780;
+			
+			// aapt resource value: 0x7f08002e
+			public static int wrap_content = 2131230766;
 			
 			static Id()
 			{
@@ -2677,35 +3629,44 @@ namespace SuaveControls.MaterialForms.Android
 		public partial class Integer
 		{
 			
-			// aapt resource value: 0x7f090004
-			public static int abc_config_activityDefaultDur = 2131296260;
+			// aapt resource value: 0x7f0a0003
+			public static int abc_config_activityDefaultDur = 2131361795;
 			
-			// aapt resource value: 0x7f090005
-			public static int abc_config_activityShortDur = 2131296261;
+			// aapt resource value: 0x7f0a0004
+			public static int abc_config_activityShortDur = 2131361796;
 			
-			// aapt resource value: 0x7f090003
-			public static int abc_max_action_buttons = 2131296259;
+			// aapt resource value: 0x7f0a0008
+			public static int app_bar_elevation_anim_duration = 2131361800;
 			
-			// aapt resource value: 0x7f090009
-			public static int bottom_sheet_slide_duration = 2131296265;
+			// aapt resource value: 0x7f0a0009
+			public static int bottom_sheet_slide_duration = 2131361801;
 			
-			// aapt resource value: 0x7f090006
-			public static int cancel_button_image_alpha = 2131296262;
+			// aapt resource value: 0x7f0a0005
+			public static int cancel_button_image_alpha = 2131361797;
 			
-			// aapt resource value: 0x7f090008
-			public static int design_snackbar_text_max_lines = 2131296264;
+			// aapt resource value: 0x7f0a0006
+			public static int config_tooltipAnimTime = 2131361798;
 			
-			// aapt resource value: 0x7f090000
-			public static int mr_controller_volume_group_list_animation_duration_ms = 2131296256;
+			// aapt resource value: 0x7f0a0007
+			public static int design_snackbar_text_max_lines = 2131361799;
 			
-			// aapt resource value: 0x7f090001
-			public static int mr_controller_volume_group_list_fade_in_duration_ms = 2131296257;
+			// aapt resource value: 0x7f0a000a
+			public static int hide_password_duration = 2131361802;
 			
-			// aapt resource value: 0x7f090002
-			public static int mr_controller_volume_group_list_fade_out_duration_ms = 2131296258;
+			// aapt resource value: 0x7f0a0000
+			public static int mr_controller_volume_group_list_animation_duration_ms = 2131361792;
 			
-			// aapt resource value: 0x7f090007
-			public static int status_bar_notification_info_maxnum = 2131296263;
+			// aapt resource value: 0x7f0a0001
+			public static int mr_controller_volume_group_list_fade_in_duration_ms = 2131361793;
+			
+			// aapt resource value: 0x7f0a0002
+			public static int mr_controller_volume_group_list_fade_out_duration_ms = 2131361794;
+			
+			// aapt resource value: 0x7f0a000b
+			public static int show_password_duration = 2131361803;
+			
+			// aapt resource value: 0x7f0a000c
+			public static int status_bar_notification_info_maxnum = 2131361804;
 			
 			static Integer()
 			{
@@ -2720,11 +3681,11 @@ namespace SuaveControls.MaterialForms.Android
 		public partial class Interpolator
 		{
 			
-			// aapt resource value: 0x7f050000
-			public static int mr_fast_out_slow_in = 2131034112;
+			// aapt resource value: 0x7f060000
+			public static int mr_fast_out_slow_in = 2131099648;
 			
-			// aapt resource value: 0x7f050001
-			public static int mr_linear_out_slow_in = 2131034113;
+			// aapt resource value: 0x7f060001
+			public static int mr_linear_out_slow_in = 2131099649;
 			
 			static Interpolator()
 			{
@@ -2746,31 +3707,31 @@ namespace SuaveControls.MaterialForms.Android
 			public static int abc_action_bar_up_container = 2130903041;
 			
 			// aapt resource value: 0x7f030002
-			public static int abc_action_bar_view_list_nav_layout = 2130903042;
+			public static int abc_action_menu_item_layout = 2130903042;
 			
 			// aapt resource value: 0x7f030003
-			public static int abc_action_menu_item_layout = 2130903043;
+			public static int abc_action_menu_layout = 2130903043;
 			
 			// aapt resource value: 0x7f030004
-			public static int abc_action_menu_layout = 2130903044;
+			public static int abc_action_mode_bar = 2130903044;
 			
 			// aapt resource value: 0x7f030005
-			public static int abc_action_mode_bar = 2130903045;
+			public static int abc_action_mode_close_item_material = 2130903045;
 			
 			// aapt resource value: 0x7f030006
-			public static int abc_action_mode_close_item_material = 2130903046;
+			public static int abc_activity_chooser_view = 2130903046;
 			
 			// aapt resource value: 0x7f030007
-			public static int abc_activity_chooser_view = 2130903047;
+			public static int abc_activity_chooser_view_list_item = 2130903047;
 			
 			// aapt resource value: 0x7f030008
-			public static int abc_activity_chooser_view_list_item = 2130903048;
+			public static int abc_alert_dialog_button_bar_material = 2130903048;
 			
 			// aapt resource value: 0x7f030009
-			public static int abc_alert_dialog_button_bar_material = 2130903049;
+			public static int abc_alert_dialog_material = 2130903049;
 			
 			// aapt resource value: 0x7f03000a
-			public static int abc_alert_dialog_material = 2130903050;
+			public static int abc_alert_dialog_title_material = 2130903050;
 			
 			// aapt resource value: 0x7f03000b
 			public static int abc_dialog_title_material = 2130903051;
@@ -2791,118 +3752,151 @@ namespace SuaveControls.MaterialForms.Android
 			public static int abc_list_menu_item_radio = 2130903056;
 			
 			// aapt resource value: 0x7f030011
-			public static int abc_popup_menu_item_layout = 2130903057;
+			public static int abc_popup_menu_header_item_layout = 2130903057;
 			
 			// aapt resource value: 0x7f030012
-			public static int abc_screen_content_include = 2130903058;
+			public static int abc_popup_menu_item_layout = 2130903058;
 			
 			// aapt resource value: 0x7f030013
-			public static int abc_screen_simple = 2130903059;
+			public static int abc_screen_content_include = 2130903059;
 			
 			// aapt resource value: 0x7f030014
-			public static int abc_screen_simple_overlay_action_mode = 2130903060;
+			public static int abc_screen_simple = 2130903060;
 			
 			// aapt resource value: 0x7f030015
-			public static int abc_screen_toolbar = 2130903061;
+			public static int abc_screen_simple_overlay_action_mode = 2130903061;
 			
 			// aapt resource value: 0x7f030016
-			public static int abc_search_dropdown_item_icons_2line = 2130903062;
+			public static int abc_screen_toolbar = 2130903062;
 			
 			// aapt resource value: 0x7f030017
-			public static int abc_search_view = 2130903063;
+			public static int abc_search_dropdown_item_icons_2line = 2130903063;
 			
 			// aapt resource value: 0x7f030018
-			public static int abc_select_dialog_material = 2130903064;
+			public static int abc_search_view = 2130903064;
 			
 			// aapt resource value: 0x7f030019
-			public static int design_bottom_sheet_dialog = 2130903065;
+			public static int abc_select_dialog_material = 2130903065;
 			
 			// aapt resource value: 0x7f03001a
-			public static int design_layout_snackbar = 2130903066;
+			public static int design_bottom_navigation_item = 2130903066;
 			
 			// aapt resource value: 0x7f03001b
-			public static int design_layout_snackbar_include = 2130903067;
+			public static int design_bottom_sheet_dialog = 2130903067;
 			
 			// aapt resource value: 0x7f03001c
-			public static int design_layout_tab_icon = 2130903068;
+			public static int design_layout_snackbar = 2130903068;
 			
 			// aapt resource value: 0x7f03001d
-			public static int design_layout_tab_text = 2130903069;
+			public static int design_layout_snackbar_include = 2130903069;
 			
 			// aapt resource value: 0x7f03001e
-			public static int design_menu_item_action_area = 2130903070;
+			public static int design_layout_tab_icon = 2130903070;
 			
 			// aapt resource value: 0x7f03001f
-			public static int design_navigation_item = 2130903071;
+			public static int design_layout_tab_text = 2130903071;
 			
 			// aapt resource value: 0x7f030020
-			public static int design_navigation_item_header = 2130903072;
+			public static int design_menu_item_action_area = 2130903072;
 			
 			// aapt resource value: 0x7f030021
-			public static int design_navigation_item_separator = 2130903073;
+			public static int design_navigation_item = 2130903073;
 			
 			// aapt resource value: 0x7f030022
-			public static int design_navigation_item_subheader = 2130903074;
+			public static int design_navigation_item_header = 2130903074;
 			
 			// aapt resource value: 0x7f030023
-			public static int design_navigation_menu = 2130903075;
+			public static int design_navigation_item_separator = 2130903075;
 			
 			// aapt resource value: 0x7f030024
-			public static int design_navigation_menu_item = 2130903076;
+			public static int design_navigation_item_subheader = 2130903076;
 			
 			// aapt resource value: 0x7f030025
-			public static int mr_chooser_dialog = 2130903077;
+			public static int design_navigation_menu = 2130903077;
 			
 			// aapt resource value: 0x7f030026
-			public static int mr_chooser_list_item = 2130903078;
+			public static int design_navigation_menu_item = 2130903078;
 			
 			// aapt resource value: 0x7f030027
-			public static int mr_controller_material_dialog_b = 2130903079;
+			public static int design_text_input_password_icon = 2130903079;
 			
 			// aapt resource value: 0x7f030028
-			public static int mr_controller_volume_item = 2130903080;
+			public static int mr_chooser_dialog = 2130903080;
 			
 			// aapt resource value: 0x7f030029
-			public static int mr_playback_control = 2130903081;
+			public static int mr_chooser_list_item = 2130903081;
 			
 			// aapt resource value: 0x7f03002a
-			public static int mr_volume_control = 2130903082;
+			public static int mr_controller_material_dialog_b = 2130903082;
 			
 			// aapt resource value: 0x7f03002b
-			public static int notification_media_action = 2130903083;
+			public static int mr_controller_volume_item = 2130903083;
 			
 			// aapt resource value: 0x7f03002c
-			public static int notification_media_cancel_action = 2130903084;
+			public static int mr_playback_control = 2130903084;
 			
 			// aapt resource value: 0x7f03002d
-			public static int notification_template_big_media = 2130903085;
+			public static int mr_volume_control = 2130903085;
 			
 			// aapt resource value: 0x7f03002e
-			public static int notification_template_big_media_narrow = 2130903086;
+			public static int notification_action = 2130903086;
 			
 			// aapt resource value: 0x7f03002f
-			public static int notification_template_lines = 2130903087;
+			public static int notification_action_tombstone = 2130903087;
 			
 			// aapt resource value: 0x7f030030
-			public static int notification_template_media = 2130903088;
+			public static int notification_media_action = 2130903088;
 			
 			// aapt resource value: 0x7f030031
-			public static int notification_template_part_chronometer = 2130903089;
+			public static int notification_media_cancel_action = 2130903089;
 			
 			// aapt resource value: 0x7f030032
-			public static int notification_template_part_time = 2130903090;
+			public static int notification_template_big_media = 2130903090;
 			
 			// aapt resource value: 0x7f030033
-			public static int select_dialog_item_material = 2130903091;
+			public static int notification_template_big_media_custom = 2130903091;
 			
 			// aapt resource value: 0x7f030034
-			public static int select_dialog_multichoice_material = 2130903092;
+			public static int notification_template_big_media_narrow = 2130903092;
 			
 			// aapt resource value: 0x7f030035
-			public static int select_dialog_singlechoice_material = 2130903093;
+			public static int notification_template_big_media_narrow_custom = 2130903093;
 			
 			// aapt resource value: 0x7f030036
-			public static int support_simple_spinner_dropdown_item = 2130903094;
+			public static int notification_template_custom_big = 2130903094;
+			
+			// aapt resource value: 0x7f030037
+			public static int notification_template_icon_group = 2130903095;
+			
+			// aapt resource value: 0x7f030038
+			public static int notification_template_lines_media = 2130903096;
+			
+			// aapt resource value: 0x7f030039
+			public static int notification_template_media = 2130903097;
+			
+			// aapt resource value: 0x7f03003a
+			public static int notification_template_media_custom = 2130903098;
+			
+			// aapt resource value: 0x7f03003b
+			public static int notification_template_part_chronometer = 2130903099;
+			
+			// aapt resource value: 0x7f03003c
+			public static int notification_template_part_time = 2130903100;
+			
+			// aapt resource value: 0x7f03003d
+			public static int select_dialog_item_material = 2130903101;
+			
+			// aapt resource value: 0x7f03003e
+			public static int select_dialog_multichoice_material = 2130903102;
+			
+			// aapt resource value: 0x7f03003f
+			public static int select_dialog_singlechoice_material = 2130903103;
+			
+			// aapt resource value: 0x7f030040
+			public static int support_simple_spinner_dropdown_item = 2130903104;
+			
+			// aapt resource value: 0x7f030041
+			public static int tooltip = 2130903105;
 			
 			static Layout()
 			{
@@ -2917,125 +3911,191 @@ namespace SuaveControls.MaterialForms.Android
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7f080027
-			public static int ApplicationName = 2131230759;
+			// aapt resource value: 0x7f09003d
+			public static int ApplicationName = 2131296317;
 			
-			// aapt resource value: 0x7f080026
-			public static int Hello = 2131230758;
+			// aapt resource value: 0x7f09003c
+			public static int Hello = 2131296316;
 			
-			// aapt resource value: 0x7f08000f
-			public static int abc_action_bar_home_description = 2131230735;
+			// aapt resource value: 0x7f090015
+			public static int abc_action_bar_home_description = 2131296277;
 			
-			// aapt resource value: 0x7f080010
-			public static int abc_action_bar_home_description_format = 2131230736;
+			// aapt resource value: 0x7f090016
+			public static int abc_action_bar_up_description = 2131296278;
 			
-			// aapt resource value: 0x7f080011
-			public static int abc_action_bar_home_subtitle_description_format = 2131230737;
+			// aapt resource value: 0x7f090017
+			public static int abc_action_menu_overflow_description = 2131296279;
 			
-			// aapt resource value: 0x7f080012
-			public static int abc_action_bar_up_description = 2131230738;
+			// aapt resource value: 0x7f090018
+			public static int abc_action_mode_done = 2131296280;
 			
-			// aapt resource value: 0x7f080013
-			public static int abc_action_menu_overflow_description = 2131230739;
+			// aapt resource value: 0x7f090019
+			public static int abc_activity_chooser_view_see_all = 2131296281;
 			
-			// aapt resource value: 0x7f080014
-			public static int abc_action_mode_done = 2131230740;
+			// aapt resource value: 0x7f09001a
+			public static int abc_activitychooserview_choose_application = 2131296282;
 			
-			// aapt resource value: 0x7f080015
-			public static int abc_activity_chooser_view_see_all = 2131230741;
+			// aapt resource value: 0x7f09001b
+			public static int abc_capital_off = 2131296283;
 			
-			// aapt resource value: 0x7f080016
-			public static int abc_activitychooserview_choose_application = 2131230742;
+			// aapt resource value: 0x7f09001c
+			public static int abc_capital_on = 2131296284;
 			
-			// aapt resource value: 0x7f080017
-			public static int abc_capital_off = 2131230743;
+			// aapt resource value: 0x7f090027
+			public static int abc_font_family_body_1_material = 2131296295;
 			
-			// aapt resource value: 0x7f080018
-			public static int abc_capital_on = 2131230744;
+			// aapt resource value: 0x7f090028
+			public static int abc_font_family_body_2_material = 2131296296;
 			
-			// aapt resource value: 0x7f080019
-			public static int abc_search_hint = 2131230745;
+			// aapt resource value: 0x7f090029
+			public static int abc_font_family_button_material = 2131296297;
 			
-			// aapt resource value: 0x7f08001a
-			public static int abc_searchview_description_clear = 2131230746;
+			// aapt resource value: 0x7f09002a
+			public static int abc_font_family_caption_material = 2131296298;
 			
-			// aapt resource value: 0x7f08001b
-			public static int abc_searchview_description_query = 2131230747;
+			// aapt resource value: 0x7f09002b
+			public static int abc_font_family_display_1_material = 2131296299;
 			
-			// aapt resource value: 0x7f08001c
-			public static int abc_searchview_description_search = 2131230748;
+			// aapt resource value: 0x7f09002c
+			public static int abc_font_family_display_2_material = 2131296300;
 			
-			// aapt resource value: 0x7f08001d
-			public static int abc_searchview_description_submit = 2131230749;
+			// aapt resource value: 0x7f09002d
+			public static int abc_font_family_display_3_material = 2131296301;
 			
-			// aapt resource value: 0x7f08001e
-			public static int abc_searchview_description_voice = 2131230750;
+			// aapt resource value: 0x7f09002e
+			public static int abc_font_family_display_4_material = 2131296302;
 			
-			// aapt resource value: 0x7f08001f
-			public static int abc_shareactionprovider_share_with = 2131230751;
+			// aapt resource value: 0x7f09002f
+			public static int abc_font_family_headline_material = 2131296303;
 			
-			// aapt resource value: 0x7f080020
-			public static int abc_shareactionprovider_share_with_application = 2131230752;
+			// aapt resource value: 0x7f090030
+			public static int abc_font_family_menu_material = 2131296304;
 			
-			// aapt resource value: 0x7f080021
-			public static int abc_toolbar_collapse_description = 2131230753;
+			// aapt resource value: 0x7f090031
+			public static int abc_font_family_subhead_material = 2131296305;
 			
-			// aapt resource value: 0x7f080023
-			public static int appbar_scrolling_view_behavior = 2131230755;
+			// aapt resource value: 0x7f090032
+			public static int abc_font_family_title_material = 2131296306;
 			
-			// aapt resource value: 0x7f080024
-			public static int bottom_sheet_behavior = 2131230756;
+			// aapt resource value: 0x7f09001d
+			public static int abc_search_hint = 2131296285;
 			
-			// aapt resource value: 0x7f080025
-			public static int character_counter_pattern = 2131230757;
+			// aapt resource value: 0x7f09001e
+			public static int abc_searchview_description_clear = 2131296286;
 			
-			// aapt resource value: 0x7f080000
-			public static int mr_button_content_description = 2131230720;
+			// aapt resource value: 0x7f09001f
+			public static int abc_searchview_description_query = 2131296287;
 			
-			// aapt resource value: 0x7f080001
-			public static int mr_chooser_searching = 2131230721;
+			// aapt resource value: 0x7f090020
+			public static int abc_searchview_description_search = 2131296288;
 			
-			// aapt resource value: 0x7f080002
-			public static int mr_chooser_title = 2131230722;
+			// aapt resource value: 0x7f090021
+			public static int abc_searchview_description_submit = 2131296289;
 			
-			// aapt resource value: 0x7f080003
-			public static int mr_controller_casting_screen = 2131230723;
+			// aapt resource value: 0x7f090022
+			public static int abc_searchview_description_voice = 2131296290;
 			
-			// aapt resource value: 0x7f080004
-			public static int mr_controller_close_description = 2131230724;
+			// aapt resource value: 0x7f090023
+			public static int abc_shareactionprovider_share_with = 2131296291;
 			
-			// aapt resource value: 0x7f080005
-			public static int mr_controller_collapse_group = 2131230725;
+			// aapt resource value: 0x7f090024
+			public static int abc_shareactionprovider_share_with_application = 2131296292;
 			
-			// aapt resource value: 0x7f080006
-			public static int mr_controller_disconnect = 2131230726;
+			// aapt resource value: 0x7f090025
+			public static int abc_toolbar_collapse_description = 2131296293;
 			
-			// aapt resource value: 0x7f080007
-			public static int mr_controller_expand_group = 2131230727;
+			// aapt resource value: 0x7f090033
+			public static int appbar_scrolling_view_behavior = 2131296307;
 			
-			// aapt resource value: 0x7f080008
-			public static int mr_controller_no_info_available = 2131230728;
+			// aapt resource value: 0x7f090034
+			public static int bottom_sheet_behavior = 2131296308;
 			
-			// aapt resource value: 0x7f080009
-			public static int mr_controller_no_media_selected = 2131230729;
+			// aapt resource value: 0x7f090035
+			public static int character_counter_pattern = 2131296309;
 			
-			// aapt resource value: 0x7f08000a
-			public static int mr_controller_pause = 2131230730;
+			// aapt resource value: 0x7f090000
+			public static int mr_button_content_description = 2131296256;
 			
-			// aapt resource value: 0x7f08000b
-			public static int mr_controller_play = 2131230731;
+			// aapt resource value: 0x7f090001
+			public static int mr_cast_button_connected = 2131296257;
 			
-			// aapt resource value: 0x7f08000c
-			public static int mr_controller_stop = 2131230732;
+			// aapt resource value: 0x7f090002
+			public static int mr_cast_button_connecting = 2131296258;
 			
-			// aapt resource value: 0x7f08000d
-			public static int mr_system_route_name = 2131230733;
+			// aapt resource value: 0x7f090003
+			public static int mr_cast_button_disconnected = 2131296259;
 			
-			// aapt resource value: 0x7f08000e
-			public static int mr_user_route_category_name = 2131230734;
+			// aapt resource value: 0x7f090004
+			public static int mr_chooser_searching = 2131296260;
 			
-			// aapt resource value: 0x7f080022
-			public static int status_bar_notification_info_overflow = 2131230754;
+			// aapt resource value: 0x7f090005
+			public static int mr_chooser_title = 2131296261;
+			
+			// aapt resource value: 0x7f090006
+			public static int mr_controller_album_art = 2131296262;
+			
+			// aapt resource value: 0x7f090007
+			public static int mr_controller_casting_screen = 2131296263;
+			
+			// aapt resource value: 0x7f090008
+			public static int mr_controller_close_description = 2131296264;
+			
+			// aapt resource value: 0x7f090009
+			public static int mr_controller_collapse_group = 2131296265;
+			
+			// aapt resource value: 0x7f09000a
+			public static int mr_controller_disconnect = 2131296266;
+			
+			// aapt resource value: 0x7f09000b
+			public static int mr_controller_expand_group = 2131296267;
+			
+			// aapt resource value: 0x7f09000c
+			public static int mr_controller_no_info_available = 2131296268;
+			
+			// aapt resource value: 0x7f09000d
+			public static int mr_controller_no_media_selected = 2131296269;
+			
+			// aapt resource value: 0x7f09000e
+			public static int mr_controller_pause = 2131296270;
+			
+			// aapt resource value: 0x7f09000f
+			public static int mr_controller_play = 2131296271;
+			
+			// aapt resource value: 0x7f090010
+			public static int mr_controller_stop = 2131296272;
+			
+			// aapt resource value: 0x7f090011
+			public static int mr_controller_stop_casting = 2131296273;
+			
+			// aapt resource value: 0x7f090012
+			public static int mr_controller_volume_slider = 2131296274;
+			
+			// aapt resource value: 0x7f090013
+			public static int mr_system_route_name = 2131296275;
+			
+			// aapt resource value: 0x7f090014
+			public static int mr_user_route_category_name = 2131296276;
+			
+			// aapt resource value: 0x7f090036
+			public static int password_toggle_content_description = 2131296310;
+			
+			// aapt resource value: 0x7f090037
+			public static int path_password_eye = 2131296311;
+			
+			// aapt resource value: 0x7f090038
+			public static int path_password_eye_mask_strike_through = 2131296312;
+			
+			// aapt resource value: 0x7f090039
+			public static int path_password_eye_mask_visible = 2131296313;
+			
+			// aapt resource value: 0x7f09003a
+			public static int path_password_strike_through = 2131296314;
+			
+			// aapt resource value: 0x7f090026
+			public static int search_menu_title = 2131296294;
+			
+			// aapt resource value: 0x7f09003b
+			public static int status_bar_notification_info_overflow = 2131296315;
 			
 			static String()
 			{
@@ -3050,1115 +4110,1202 @@ namespace SuaveControls.MaterialForms.Android
 		public partial class Style
 		{
 			
-			// aapt resource value: 0x7f0a00a1
-			public static int AlertDialog_AppCompat = 2131361953;
+			// aapt resource value: 0x7f0b00a4
+			public static int AlertDialog_AppCompat = 2131427492;
 			
-			// aapt resource value: 0x7f0a00a2
-			public static int AlertDialog_AppCompat_Light = 2131361954;
+			// aapt resource value: 0x7f0b00a5
+			public static int AlertDialog_AppCompat_Light = 2131427493;
 			
-			// aapt resource value: 0x7f0a00a3
-			public static int Animation_AppCompat_Dialog = 2131361955;
+			// aapt resource value: 0x7f0b00a6
+			public static int Animation_AppCompat_Dialog = 2131427494;
 			
-			// aapt resource value: 0x7f0a00a4
-			public static int Animation_AppCompat_DropDownUp = 2131361956;
+			// aapt resource value: 0x7f0b00a7
+			public static int Animation_AppCompat_DropDownUp = 2131427495;
 			
-			// aapt resource value: 0x7f0a015a
-			public static int Animation_Design_BottomSheetDialog = 2131362138;
+			// aapt resource value: 0x7f0b00a8
+			public static int Animation_AppCompat_Tooltip = 2131427496;
 			
-			// aapt resource value: 0x7f0a00a5
-			public static int Base_AlertDialog_AppCompat = 2131361957;
+			// aapt resource value: 0x7f0b016e
+			public static int Animation_Design_BottomSheetDialog = 2131427694;
 			
-			// aapt resource value: 0x7f0a00a6
-			public static int Base_AlertDialog_AppCompat_Light = 2131361958;
+			// aapt resource value: 0x7f0b00a9
+			public static int Base_AlertDialog_AppCompat = 2131427497;
 			
-			// aapt resource value: 0x7f0a00a7
-			public static int Base_Animation_AppCompat_Dialog = 2131361959;
+			// aapt resource value: 0x7f0b00aa
+			public static int Base_AlertDialog_AppCompat_Light = 2131427498;
 			
-			// aapt resource value: 0x7f0a00a8
-			public static int Base_Animation_AppCompat_DropDownUp = 2131361960;
+			// aapt resource value: 0x7f0b00ab
+			public static int Base_Animation_AppCompat_Dialog = 2131427499;
 			
-			// aapt resource value: 0x7f0a0018
-			public static int Base_CardView = 2131361816;
+			// aapt resource value: 0x7f0b00ac
+			public static int Base_Animation_AppCompat_DropDownUp = 2131427500;
 			
-			// aapt resource value: 0x7f0a00a9
-			public static int Base_DialogWindowTitle_AppCompat = 2131361961;
+			// aapt resource value: 0x7f0b00ad
+			public static int Base_Animation_AppCompat_Tooltip = 2131427501;
 			
-			// aapt resource value: 0x7f0a00aa
-			public static int Base_DialogWindowTitleBackground_AppCompat = 2131361962;
+			// aapt resource value: 0x7f0b000c
+			public static int Base_CardView = 2131427340;
 			
-			// aapt resource value: 0x7f0a0051
-			public static int Base_TextAppearance_AppCompat = 2131361873;
+			// aapt resource value: 0x7f0b00ae
+			public static int Base_DialogWindowTitle_AppCompat = 2131427502;
 			
-			// aapt resource value: 0x7f0a0052
-			public static int Base_TextAppearance_AppCompat_Body1 = 2131361874;
+			// aapt resource value: 0x7f0b00af
+			public static int Base_DialogWindowTitleBackground_AppCompat = 2131427503;
 			
-			// aapt resource value: 0x7f0a0053
-			public static int Base_TextAppearance_AppCompat_Body2 = 2131361875;
+			// aapt resource value: 0x7f0b0048
+			public static int Base_TextAppearance_AppCompat = 2131427400;
 			
-			// aapt resource value: 0x7f0a003b
-			public static int Base_TextAppearance_AppCompat_Button = 2131361851;
+			// aapt resource value: 0x7f0b0049
+			public static int Base_TextAppearance_AppCompat_Body1 = 2131427401;
 			
-			// aapt resource value: 0x7f0a0054
-			public static int Base_TextAppearance_AppCompat_Caption = 2131361876;
+			// aapt resource value: 0x7f0b004a
+			public static int Base_TextAppearance_AppCompat_Body2 = 2131427402;
 			
-			// aapt resource value: 0x7f0a0055
-			public static int Base_TextAppearance_AppCompat_Display1 = 2131361877;
+			// aapt resource value: 0x7f0b0036
+			public static int Base_TextAppearance_AppCompat_Button = 2131427382;
 			
-			// aapt resource value: 0x7f0a0056
-			public static int Base_TextAppearance_AppCompat_Display2 = 2131361878;
+			// aapt resource value: 0x7f0b004b
+			public static int Base_TextAppearance_AppCompat_Caption = 2131427403;
 			
-			// aapt resource value: 0x7f0a0057
-			public static int Base_TextAppearance_AppCompat_Display3 = 2131361879;
+			// aapt resource value: 0x7f0b004c
+			public static int Base_TextAppearance_AppCompat_Display1 = 2131427404;
 			
-			// aapt resource value: 0x7f0a0058
-			public static int Base_TextAppearance_AppCompat_Display4 = 2131361880;
+			// aapt resource value: 0x7f0b004d
+			public static int Base_TextAppearance_AppCompat_Display2 = 2131427405;
 			
-			// aapt resource value: 0x7f0a0059
-			public static int Base_TextAppearance_AppCompat_Headline = 2131361881;
+			// aapt resource value: 0x7f0b004e
+			public static int Base_TextAppearance_AppCompat_Display3 = 2131427406;
 			
-			// aapt resource value: 0x7f0a0026
-			public static int Base_TextAppearance_AppCompat_Inverse = 2131361830;
+			// aapt resource value: 0x7f0b004f
+			public static int Base_TextAppearance_AppCompat_Display4 = 2131427407;
 			
-			// aapt resource value: 0x7f0a005a
-			public static int Base_TextAppearance_AppCompat_Large = 2131361882;
+			// aapt resource value: 0x7f0b0050
+			public static int Base_TextAppearance_AppCompat_Headline = 2131427408;
 			
-			// aapt resource value: 0x7f0a0027
-			public static int Base_TextAppearance_AppCompat_Large_Inverse = 2131361831;
+			// aapt resource value: 0x7f0b001a
+			public static int Base_TextAppearance_AppCompat_Inverse = 2131427354;
 			
-			// aapt resource value: 0x7f0a005b
-			public static int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131361883;
+			// aapt resource value: 0x7f0b0051
+			public static int Base_TextAppearance_AppCompat_Large = 2131427409;
 			
-			// aapt resource value: 0x7f0a005c
-			public static int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131361884;
+			// aapt resource value: 0x7f0b001b
+			public static int Base_TextAppearance_AppCompat_Large_Inverse = 2131427355;
 			
-			// aapt resource value: 0x7f0a005d
-			public static int Base_TextAppearance_AppCompat_Medium = 2131361885;
+			// aapt resource value: 0x7f0b0052
+			public static int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131427410;
 			
-			// aapt resource value: 0x7f0a0028
-			public static int Base_TextAppearance_AppCompat_Medium_Inverse = 2131361832;
+			// aapt resource value: 0x7f0b0053
+			public static int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131427411;
 			
-			// aapt resource value: 0x7f0a005e
-			public static int Base_TextAppearance_AppCompat_Menu = 2131361886;
+			// aapt resource value: 0x7f0b0054
+			public static int Base_TextAppearance_AppCompat_Medium = 2131427412;
 			
-			// aapt resource value: 0x7f0a00ab
-			public static int Base_TextAppearance_AppCompat_SearchResult = 2131361963;
+			// aapt resource value: 0x7f0b001c
+			public static int Base_TextAppearance_AppCompat_Medium_Inverse = 2131427356;
 			
-			// aapt resource value: 0x7f0a005f
-			public static int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131361887;
+			// aapt resource value: 0x7f0b0055
+			public static int Base_TextAppearance_AppCompat_Menu = 2131427413;
 			
-			// aapt resource value: 0x7f0a0060
-			public static int Base_TextAppearance_AppCompat_SearchResult_Title = 2131361888;
+			// aapt resource value: 0x7f0b00b0
+			public static int Base_TextAppearance_AppCompat_SearchResult = 2131427504;
 			
-			// aapt resource value: 0x7f0a0061
-			public static int Base_TextAppearance_AppCompat_Small = 2131361889;
+			// aapt resource value: 0x7f0b0056
+			public static int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131427414;
 			
-			// aapt resource value: 0x7f0a0029
-			public static int Base_TextAppearance_AppCompat_Small_Inverse = 2131361833;
+			// aapt resource value: 0x7f0b0057
+			public static int Base_TextAppearance_AppCompat_SearchResult_Title = 2131427415;
 			
-			// aapt resource value: 0x7f0a0062
-			public static int Base_TextAppearance_AppCompat_Subhead = 2131361890;
+			// aapt resource value: 0x7f0b0058
+			public static int Base_TextAppearance_AppCompat_Small = 2131427416;
 			
-			// aapt resource value: 0x7f0a002a
-			public static int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131361834;
+			// aapt resource value: 0x7f0b001d
+			public static int Base_TextAppearance_AppCompat_Small_Inverse = 2131427357;
 			
-			// aapt resource value: 0x7f0a0063
-			public static int Base_TextAppearance_AppCompat_Title = 2131361891;
+			// aapt resource value: 0x7f0b0059
+			public static int Base_TextAppearance_AppCompat_Subhead = 2131427417;
 			
-			// aapt resource value: 0x7f0a002b
-			public static int Base_TextAppearance_AppCompat_Title_Inverse = 2131361835;
+			// aapt resource value: 0x7f0b001e
+			public static int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131427358;
 			
-			// aapt resource value: 0x7f0a009a
-			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131361946;
+			// aapt resource value: 0x7f0b005a
+			public static int Base_TextAppearance_AppCompat_Title = 2131427418;
 			
-			// aapt resource value: 0x7f0a0064
-			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131361892;
+			// aapt resource value: 0x7f0b001f
+			public static int Base_TextAppearance_AppCompat_Title_Inverse = 2131427359;
 			
-			// aapt resource value: 0x7f0a0065
-			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131361893;
+			// aapt resource value: 0x7f0b00b1
+			public static int Base_TextAppearance_AppCompat_Tooltip = 2131427505;
 			
-			// aapt resource value: 0x7f0a0066
-			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131361894;
+			// aapt resource value: 0x7f0b0095
+			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131427477;
 			
-			// aapt resource value: 0x7f0a0067
-			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131361895;
+			// aapt resource value: 0x7f0b005b
+			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131427419;
 			
-			// aapt resource value: 0x7f0a0068
-			public static int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131361896;
+			// aapt resource value: 0x7f0b005c
+			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131427420;
 			
-			// aapt resource value: 0x7f0a0069
-			public static int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131361897;
+			// aapt resource value: 0x7f0b005d
+			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131427421;
 			
-			// aapt resource value: 0x7f0a006a
-			public static int Base_TextAppearance_AppCompat_Widget_Button = 2131361898;
+			// aapt resource value: 0x7f0b005e
+			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131427422;
 			
-			// aapt resource value: 0x7f0a009b
-			public static int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131361947;
+			// aapt resource value: 0x7f0b005f
+			public static int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131427423;
 			
-			// aapt resource value: 0x7f0a00ac
-			public static int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131361964;
+			// aapt resource value: 0x7f0b0060
+			public static int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131427424;
 			
-			// aapt resource value: 0x7f0a006b
-			public static int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131361899;
+			// aapt resource value: 0x7f0b0061
+			public static int Base_TextAppearance_AppCompat_Widget_Button = 2131427425;
 			
-			// aapt resource value: 0x7f0a006c
-			public static int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131361900;
+			// aapt resource value: 0x7f0b009c
+			public static int Base_TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131427484;
 			
-			// aapt resource value: 0x7f0a006d
-			public static int Base_TextAppearance_AppCompat_Widget_Switch = 2131361901;
+			// aapt resource value: 0x7f0b009d
+			public static int Base_TextAppearance_AppCompat_Widget_Button_Colored = 2131427485;
 			
-			// aapt resource value: 0x7f0a006e
-			public static int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131361902;
+			// aapt resource value: 0x7f0b0096
+			public static int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131427478;
 			
-			// aapt resource value: 0x7f0a00ad
-			public static int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131361965;
+			// aapt resource value: 0x7f0b00b2
+			public static int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131427506;
 			
-			// aapt resource value: 0x7f0a006f
-			public static int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131361903;
+			// aapt resource value: 0x7f0b0062
+			public static int Base_TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131427426;
 			
-			// aapt resource value: 0x7f0a0070
-			public static int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131361904;
+			// aapt resource value: 0x7f0b0063
+			public static int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131427427;
 			
-			// aapt resource value: 0x7f0a0071
-			public static int Base_Theme_AppCompat = 2131361905;
+			// aapt resource value: 0x7f0b0064
+			public static int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131427428;
 			
-			// aapt resource value: 0x7f0a00ae
-			public static int Base_Theme_AppCompat_CompactMenu = 2131361966;
+			// aapt resource value: 0x7f0b0065
+			public static int Base_TextAppearance_AppCompat_Widget_Switch = 2131427429;
 			
-			// aapt resource value: 0x7f0a002c
-			public static int Base_Theme_AppCompat_Dialog = 2131361836;
+			// aapt resource value: 0x7f0b0066
+			public static int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131427430;
 			
-			// aapt resource value: 0x7f0a00af
-			public static int Base_Theme_AppCompat_Dialog_Alert = 2131361967;
+			// aapt resource value: 0x7f0b00b3
+			public static int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131427507;
 			
-			// aapt resource value: 0x7f0a00b0
-			public static int Base_Theme_AppCompat_Dialog_FixedSize = 2131361968;
+			// aapt resource value: 0x7f0b0067
+			public static int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131427431;
 			
-			// aapt resource value: 0x7f0a00b1
-			public static int Base_Theme_AppCompat_Dialog_MinWidth = 2131361969;
+			// aapt resource value: 0x7f0b0068
+			public static int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131427432;
 			
-			// aapt resource value: 0x7f0a001c
-			public static int Base_Theme_AppCompat_DialogWhenLarge = 2131361820;
+			// aapt resource value: 0x7f0b0069
+			public static int Base_Theme_AppCompat = 2131427433;
 			
-			// aapt resource value: 0x7f0a0072
-			public static int Base_Theme_AppCompat_Light = 2131361906;
+			// aapt resource value: 0x7f0b00b4
+			public static int Base_Theme_AppCompat_CompactMenu = 2131427508;
 			
-			// aapt resource value: 0x7f0a00b2
-			public static int Base_Theme_AppCompat_Light_DarkActionBar = 2131361970;
+			// aapt resource value: 0x7f0b0020
+			public static int Base_Theme_AppCompat_Dialog = 2131427360;
 			
-			// aapt resource value: 0x7f0a002d
-			public static int Base_Theme_AppCompat_Light_Dialog = 2131361837;
+			// aapt resource value: 0x7f0b0021
+			public static int Base_Theme_AppCompat_Dialog_Alert = 2131427361;
 			
-			// aapt resource value: 0x7f0a00b3
-			public static int Base_Theme_AppCompat_Light_Dialog_Alert = 2131361971;
+			// aapt resource value: 0x7f0b00b5
+			public static int Base_Theme_AppCompat_Dialog_FixedSize = 2131427509;
 			
-			// aapt resource value: 0x7f0a00b4
-			public static int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131361972;
+			// aapt resource value: 0x7f0b0022
+			public static int Base_Theme_AppCompat_Dialog_MinWidth = 2131427362;
 			
-			// aapt resource value: 0x7f0a00b5
-			public static int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131361973;
+			// aapt resource value: 0x7f0b0010
+			public static int Base_Theme_AppCompat_DialogWhenLarge = 2131427344;
 			
-			// aapt resource value: 0x7f0a001d
-			public static int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131361821;
+			// aapt resource value: 0x7f0b006a
+			public static int Base_Theme_AppCompat_Light = 2131427434;
 			
-			// aapt resource value: 0x7f0a00b6
-			public static int Base_ThemeOverlay_AppCompat = 2131361974;
+			// aapt resource value: 0x7f0b00b6
+			public static int Base_Theme_AppCompat_Light_DarkActionBar = 2131427510;
 			
-			// aapt resource value: 0x7f0a00b7
-			public static int Base_ThemeOverlay_AppCompat_ActionBar = 2131361975;
+			// aapt resource value: 0x7f0b0023
+			public static int Base_Theme_AppCompat_Light_Dialog = 2131427363;
 			
-			// aapt resource value: 0x7f0a00b8
-			public static int Base_ThemeOverlay_AppCompat_Dark = 2131361976;
+			// aapt resource value: 0x7f0b0024
+			public static int Base_Theme_AppCompat_Light_Dialog_Alert = 2131427364;
 			
-			// aapt resource value: 0x7f0a00b9
-			public static int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131361977;
+			// aapt resource value: 0x7f0b00b7
+			public static int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131427511;
 			
-			// aapt resource value: 0x7f0a00ba
-			public static int Base_ThemeOverlay_AppCompat_Light = 2131361978;
+			// aapt resource value: 0x7f0b0025
+			public static int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131427365;
 			
-			// aapt resource value: 0x7f0a002e
-			public static int Base_V11_Theme_AppCompat_Dialog = 2131361838;
+			// aapt resource value: 0x7f0b0011
+			public static int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131427345;
 			
-			// aapt resource value: 0x7f0a002f
-			public static int Base_V11_Theme_AppCompat_Light_Dialog = 2131361839;
+			// aapt resource value: 0x7f0b00b8
+			public static int Base_ThemeOverlay_AppCompat = 2131427512;
 			
-			// aapt resource value: 0x7f0a0037
-			public static int Base_V12_Widget_AppCompat_AutoCompleteTextView = 2131361847;
+			// aapt resource value: 0x7f0b00b9
+			public static int Base_ThemeOverlay_AppCompat_ActionBar = 2131427513;
 			
-			// aapt resource value: 0x7f0a0038
-			public static int Base_V12_Widget_AppCompat_EditText = 2131361848;
+			// aapt resource value: 0x7f0b00ba
+			public static int Base_ThemeOverlay_AppCompat_Dark = 2131427514;
 			
-			// aapt resource value: 0x7f0a0073
-			public static int Base_V21_Theme_AppCompat = 2131361907;
+			// aapt resource value: 0x7f0b00bb
+			public static int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131427515;
 			
-			// aapt resource value: 0x7f0a0074
-			public static int Base_V21_Theme_AppCompat_Dialog = 2131361908;
+			// aapt resource value: 0x7f0b0026
+			public static int Base_ThemeOverlay_AppCompat_Dialog = 2131427366;
 			
-			// aapt resource value: 0x7f0a0075
-			public static int Base_V21_Theme_AppCompat_Light = 2131361909;
+			// aapt resource value: 0x7f0b0027
+			public static int Base_ThemeOverlay_AppCompat_Dialog_Alert = 2131427367;
 			
-			// aapt resource value: 0x7f0a0076
-			public static int Base_V21_Theme_AppCompat_Light_Dialog = 2131361910;
+			// aapt resource value: 0x7f0b00bc
+			public static int Base_ThemeOverlay_AppCompat_Light = 2131427516;
 			
-			// aapt resource value: 0x7f0a0098
-			public static int Base_V22_Theme_AppCompat = 2131361944;
+			// aapt resource value: 0x7f0b0028
+			public static int Base_V11_Theme_AppCompat_Dialog = 2131427368;
 			
-			// aapt resource value: 0x7f0a0099
-			public static int Base_V22_Theme_AppCompat_Light = 2131361945;
+			// aapt resource value: 0x7f0b0029
+			public static int Base_V11_Theme_AppCompat_Light_Dialog = 2131427369;
 			
-			// aapt resource value: 0x7f0a009c
-			public static int Base_V23_Theme_AppCompat = 2131361948;
+			// aapt resource value: 0x7f0b002a
+			public static int Base_V11_ThemeOverlay_AppCompat_Dialog = 2131427370;
 			
-			// aapt resource value: 0x7f0a009d
-			public static int Base_V23_Theme_AppCompat_Light = 2131361949;
+			// aapt resource value: 0x7f0b0032
+			public static int Base_V12_Widget_AppCompat_AutoCompleteTextView = 2131427378;
 			
-			// aapt resource value: 0x7f0a00bb
-			public static int Base_V7_Theme_AppCompat = 2131361979;
+			// aapt resource value: 0x7f0b0033
+			public static int Base_V12_Widget_AppCompat_EditText = 2131427379;
 			
-			// aapt resource value: 0x7f0a00bc
-			public static int Base_V7_Theme_AppCompat_Dialog = 2131361980;
+			// aapt resource value: 0x7f0b016f
+			public static int Base_V14_Widget_Design_AppBarLayout = 2131427695;
 			
-			// aapt resource value: 0x7f0a00bd
-			public static int Base_V7_Theme_AppCompat_Light = 2131361981;
+			// aapt resource value: 0x7f0b006b
+			public static int Base_V21_Theme_AppCompat = 2131427435;
 			
-			// aapt resource value: 0x7f0a00be
-			public static int Base_V7_Theme_AppCompat_Light_Dialog = 2131361982;
+			// aapt resource value: 0x7f0b006c
+			public static int Base_V21_Theme_AppCompat_Dialog = 2131427436;
 			
-			// aapt resource value: 0x7f0a00bf
-			public static int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131361983;
+			// aapt resource value: 0x7f0b006d
+			public static int Base_V21_Theme_AppCompat_Light = 2131427437;
 			
-			// aapt resource value: 0x7f0a00c0
-			public static int Base_V7_Widget_AppCompat_EditText = 2131361984;
+			// aapt resource value: 0x7f0b006e
+			public static int Base_V21_Theme_AppCompat_Light_Dialog = 2131427438;
 			
-			// aapt resource value: 0x7f0a00c1
-			public static int Base_Widget_AppCompat_ActionBar = 2131361985;
+			// aapt resource value: 0x7f0b006f
+			public static int Base_V21_ThemeOverlay_AppCompat_Dialog = 2131427439;
 			
-			// aapt resource value: 0x7f0a00c2
-			public static int Base_Widget_AppCompat_ActionBar_Solid = 2131361986;
+			// aapt resource value: 0x7f0b016b
+			public static int Base_V21_Widget_Design_AppBarLayout = 2131427691;
 			
-			// aapt resource value: 0x7f0a00c3
-			public static int Base_Widget_AppCompat_ActionBar_TabBar = 2131361987;
+			// aapt resource value: 0x7f0b0093
+			public static int Base_V22_Theme_AppCompat = 2131427475;
 			
-			// aapt resource value: 0x7f0a0077
-			public static int Base_Widget_AppCompat_ActionBar_TabText = 2131361911;
+			// aapt resource value: 0x7f0b0094
+			public static int Base_V22_Theme_AppCompat_Light = 2131427476;
 			
-			// aapt resource value: 0x7f0a0078
-			public static int Base_Widget_AppCompat_ActionBar_TabView = 2131361912;
+			// aapt resource value: 0x7f0b0097
+			public static int Base_V23_Theme_AppCompat = 2131427479;
 			
-			// aapt resource value: 0x7f0a0079
-			public static int Base_Widget_AppCompat_ActionButton = 2131361913;
+			// aapt resource value: 0x7f0b0098
+			public static int Base_V23_Theme_AppCompat_Light = 2131427480;
 			
-			// aapt resource value: 0x7f0a007a
-			public static int Base_Widget_AppCompat_ActionButton_CloseMode = 2131361914;
+			// aapt resource value: 0x7f0b00a0
+			public static int Base_V26_Theme_AppCompat = 2131427488;
 			
-			// aapt resource value: 0x7f0a007b
-			public static int Base_Widget_AppCompat_ActionButton_Overflow = 2131361915;
+			// aapt resource value: 0x7f0b00a1
+			public static int Base_V26_Theme_AppCompat_Light = 2131427489;
 			
-			// aapt resource value: 0x7f0a00c4
-			public static int Base_Widget_AppCompat_ActionMode = 2131361988;
+			// aapt resource value: 0x7f0b00a2
+			public static int Base_V26_Widget_AppCompat_Toolbar = 2131427490;
 			
-			// aapt resource value: 0x7f0a00c5
-			public static int Base_Widget_AppCompat_ActivityChooserView = 2131361989;
+			// aapt resource value: 0x7f0b016d
+			public static int Base_V26_Widget_Design_AppBarLayout = 2131427693;
 			
-			// aapt resource value: 0x7f0a0039
-			public static int Base_Widget_AppCompat_AutoCompleteTextView = 2131361849;
+			// aapt resource value: 0x7f0b00bd
+			public static int Base_V7_Theme_AppCompat = 2131427517;
 			
-			// aapt resource value: 0x7f0a007c
-			public static int Base_Widget_AppCompat_Button = 2131361916;
+			// aapt resource value: 0x7f0b00be
+			public static int Base_V7_Theme_AppCompat_Dialog = 2131427518;
 			
-			// aapt resource value: 0x7f0a007d
-			public static int Base_Widget_AppCompat_Button_Borderless = 2131361917;
+			// aapt resource value: 0x7f0b00bf
+			public static int Base_V7_Theme_AppCompat_Light = 2131427519;
 			
-			// aapt resource value: 0x7f0a007e
-			public static int Base_Widget_AppCompat_Button_Borderless_Colored = 2131361918;
+			// aapt resource value: 0x7f0b00c0
+			public static int Base_V7_Theme_AppCompat_Light_Dialog = 2131427520;
 			
-			// aapt resource value: 0x7f0a00c6
-			public static int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131361990;
+			// aapt resource value: 0x7f0b00c1
+			public static int Base_V7_ThemeOverlay_AppCompat_Dialog = 2131427521;
 			
-			// aapt resource value: 0x7f0a009e
-			public static int Base_Widget_AppCompat_Button_Colored = 2131361950;
+			// aapt resource value: 0x7f0b00c2
+			public static int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131427522;
 			
-			// aapt resource value: 0x7f0a007f
-			public static int Base_Widget_AppCompat_Button_Small = 2131361919;
+			// aapt resource value: 0x7f0b00c3
+			public static int Base_V7_Widget_AppCompat_EditText = 2131427523;
 			
-			// aapt resource value: 0x7f0a0080
-			public static int Base_Widget_AppCompat_ButtonBar = 2131361920;
+			// aapt resource value: 0x7f0b00c4
+			public static int Base_V7_Widget_AppCompat_Toolbar = 2131427524;
 			
-			// aapt resource value: 0x7f0a00c7
-			public static int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131361991;
+			// aapt resource value: 0x7f0b00c5
+			public static int Base_Widget_AppCompat_ActionBar = 2131427525;
 			
-			// aapt resource value: 0x7f0a0081
-			public static int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131361921;
+			// aapt resource value: 0x7f0b00c6
+			public static int Base_Widget_AppCompat_ActionBar_Solid = 2131427526;
 			
-			// aapt resource value: 0x7f0a0082
-			public static int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131361922;
+			// aapt resource value: 0x7f0b00c7
+			public static int Base_Widget_AppCompat_ActionBar_TabBar = 2131427527;
 			
-			// aapt resource value: 0x7f0a00c8
-			public static int Base_Widget_AppCompat_CompoundButton_Switch = 2131361992;
+			// aapt resource value: 0x7f0b0070
+			public static int Base_Widget_AppCompat_ActionBar_TabText = 2131427440;
 			
-			// aapt resource value: 0x7f0a001b
-			public static int Base_Widget_AppCompat_DrawerArrowToggle = 2131361819;
+			// aapt resource value: 0x7f0b0071
+			public static int Base_Widget_AppCompat_ActionBar_TabView = 2131427441;
 			
-			// aapt resource value: 0x7f0a00c9
-			public static int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131361993;
+			// aapt resource value: 0x7f0b0072
+			public static int Base_Widget_AppCompat_ActionButton = 2131427442;
 			
-			// aapt resource value: 0x7f0a0083
-			public static int Base_Widget_AppCompat_DropDownItem_Spinner = 2131361923;
+			// aapt resource value: 0x7f0b0073
+			public static int Base_Widget_AppCompat_ActionButton_CloseMode = 2131427443;
 			
-			// aapt resource value: 0x7f0a003a
-			public static int Base_Widget_AppCompat_EditText = 2131361850;
+			// aapt resource value: 0x7f0b0074
+			public static int Base_Widget_AppCompat_ActionButton_Overflow = 2131427444;
 			
-			// aapt resource value: 0x7f0a0084
-			public static int Base_Widget_AppCompat_ImageButton = 2131361924;
+			// aapt resource value: 0x7f0b00c8
+			public static int Base_Widget_AppCompat_ActionMode = 2131427528;
 			
-			// aapt resource value: 0x7f0a00ca
-			public static int Base_Widget_AppCompat_Light_ActionBar = 2131361994;
+			// aapt resource value: 0x7f0b00c9
+			public static int Base_Widget_AppCompat_ActivityChooserView = 2131427529;
 			
-			// aapt resource value: 0x7f0a00cb
-			public static int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131361995;
+			// aapt resource value: 0x7f0b0034
+			public static int Base_Widget_AppCompat_AutoCompleteTextView = 2131427380;
 			
-			// aapt resource value: 0x7f0a00cc
-			public static int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131361996;
+			// aapt resource value: 0x7f0b0075
+			public static int Base_Widget_AppCompat_Button = 2131427445;
 			
-			// aapt resource value: 0x7f0a0085
-			public static int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131361925;
+			// aapt resource value: 0x7f0b0076
+			public static int Base_Widget_AppCompat_Button_Borderless = 2131427446;
 			
-			// aapt resource value: 0x7f0a0086
-			public static int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131361926;
+			// aapt resource value: 0x7f0b0077
+			public static int Base_Widget_AppCompat_Button_Borderless_Colored = 2131427447;
 			
-			// aapt resource value: 0x7f0a0087
-			public static int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131361927;
+			// aapt resource value: 0x7f0b00ca
+			public static int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131427530;
 			
-			// aapt resource value: 0x7f0a0088
-			public static int Base_Widget_AppCompat_Light_PopupMenu = 2131361928;
+			// aapt resource value: 0x7f0b0099
+			public static int Base_Widget_AppCompat_Button_Colored = 2131427481;
 			
-			// aapt resource value: 0x7f0a0089
-			public static int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131361929;
+			// aapt resource value: 0x7f0b0078
+			public static int Base_Widget_AppCompat_Button_Small = 2131427448;
 			
-			// aapt resource value: 0x7f0a008a
-			public static int Base_Widget_AppCompat_ListPopupWindow = 2131361930;
+			// aapt resource value: 0x7f0b0079
+			public static int Base_Widget_AppCompat_ButtonBar = 2131427449;
 			
-			// aapt resource value: 0x7f0a008b
-			public static int Base_Widget_AppCompat_ListView = 2131361931;
+			// aapt resource value: 0x7f0b00cb
+			public static int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131427531;
 			
-			// aapt resource value: 0x7f0a008c
-			public static int Base_Widget_AppCompat_ListView_DropDown = 2131361932;
+			// aapt resource value: 0x7f0b007a
+			public static int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131427450;
 			
-			// aapt resource value: 0x7f0a008d
-			public static int Base_Widget_AppCompat_ListView_Menu = 2131361933;
+			// aapt resource value: 0x7f0b007b
+			public static int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131427451;
 			
-			// aapt resource value: 0x7f0a008e
-			public static int Base_Widget_AppCompat_PopupMenu = 2131361934;
+			// aapt resource value: 0x7f0b00cc
+			public static int Base_Widget_AppCompat_CompoundButton_Switch = 2131427532;
 			
-			// aapt resource value: 0x7f0a008f
-			public static int Base_Widget_AppCompat_PopupMenu_Overflow = 2131361935;
+			// aapt resource value: 0x7f0b000f
+			public static int Base_Widget_AppCompat_DrawerArrowToggle = 2131427343;
 			
-			// aapt resource value: 0x7f0a00cd
-			public static int Base_Widget_AppCompat_PopupWindow = 2131361997;
+			// aapt resource value: 0x7f0b00cd
+			public static int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131427533;
 			
-			// aapt resource value: 0x7f0a0030
-			public static int Base_Widget_AppCompat_ProgressBar = 2131361840;
+			// aapt resource value: 0x7f0b007c
+			public static int Base_Widget_AppCompat_DropDownItem_Spinner = 2131427452;
 			
-			// aapt resource value: 0x7f0a0031
-			public static int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131361841;
+			// aapt resource value: 0x7f0b0035
+			public static int Base_Widget_AppCompat_EditText = 2131427381;
 			
-			// aapt resource value: 0x7f0a0090
-			public static int Base_Widget_AppCompat_RatingBar = 2131361936;
+			// aapt resource value: 0x7f0b007d
+			public static int Base_Widget_AppCompat_ImageButton = 2131427453;
 			
-			// aapt resource value: 0x7f0a009f
-			public static int Base_Widget_AppCompat_RatingBar_Indicator = 2131361951;
+			// aapt resource value: 0x7f0b00ce
+			public static int Base_Widget_AppCompat_Light_ActionBar = 2131427534;
 			
-			// aapt resource value: 0x7f0a00a0
-			public static int Base_Widget_AppCompat_RatingBar_Small = 2131361952;
+			// aapt resource value: 0x7f0b00cf
+			public static int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131427535;
 			
-			// aapt resource value: 0x7f0a00ce
-			public static int Base_Widget_AppCompat_SearchView = 2131361998;
+			// aapt resource value: 0x7f0b00d0
+			public static int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131427536;
 			
-			// aapt resource value: 0x7f0a00cf
-			public static int Base_Widget_AppCompat_SearchView_ActionBar = 2131361999;
+			// aapt resource value: 0x7f0b007e
+			public static int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131427454;
 			
-			// aapt resource value: 0x7f0a0091
-			public static int Base_Widget_AppCompat_SeekBar = 2131361937;
+			// aapt resource value: 0x7f0b007f
+			public static int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131427455;
 			
-			// aapt resource value: 0x7f0a0092
-			public static int Base_Widget_AppCompat_Spinner = 2131361938;
+			// aapt resource value: 0x7f0b0080
+			public static int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131427456;
 			
-			// aapt resource value: 0x7f0a001e
-			public static int Base_Widget_AppCompat_Spinner_Underlined = 2131361822;
+			// aapt resource value: 0x7f0b0081
+			public static int Base_Widget_AppCompat_Light_PopupMenu = 2131427457;
 			
-			// aapt resource value: 0x7f0a0093
-			public static int Base_Widget_AppCompat_TextView_SpinnerItem = 2131361939;
+			// aapt resource value: 0x7f0b0082
+			public static int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131427458;
 			
-			// aapt resource value: 0x7f0a00d0
-			public static int Base_Widget_AppCompat_Toolbar = 2131362000;
+			// aapt resource value: 0x7f0b00d1
+			public static int Base_Widget_AppCompat_ListMenuView = 2131427537;
 			
-			// aapt resource value: 0x7f0a0094
-			public static int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131361940;
+			// aapt resource value: 0x7f0b0083
+			public static int Base_Widget_AppCompat_ListPopupWindow = 2131427459;
 			
-			// aapt resource value: 0x7f0a015b
-			public static int Base_Widget_Design_TabLayout = 2131362139;
+			// aapt resource value: 0x7f0b0084
+			public static int Base_Widget_AppCompat_ListView = 2131427460;
 			
-			// aapt resource value: 0x7f0a0017
-			public static int CardView = 2131361815;
+			// aapt resource value: 0x7f0b0085
+			public static int Base_Widget_AppCompat_ListView_DropDown = 2131427461;
 			
-			// aapt resource value: 0x7f0a0019
-			public static int CardView_Dark = 2131361817;
+			// aapt resource value: 0x7f0b0086
+			public static int Base_Widget_AppCompat_ListView_Menu = 2131427462;
 			
-			// aapt resource value: 0x7f0a001a
-			public static int CardView_Light = 2131361818;
+			// aapt resource value: 0x7f0b0087
+			public static int Base_Widget_AppCompat_PopupMenu = 2131427463;
 			
-			// aapt resource value: 0x7f0a0032
-			public static int Platform_AppCompat = 2131361842;
+			// aapt resource value: 0x7f0b0088
+			public static int Base_Widget_AppCompat_PopupMenu_Overflow = 2131427464;
 			
-			// aapt resource value: 0x7f0a0033
-			public static int Platform_AppCompat_Light = 2131361843;
+			// aapt resource value: 0x7f0b00d2
+			public static int Base_Widget_AppCompat_PopupWindow = 2131427538;
 			
-			// aapt resource value: 0x7f0a0095
-			public static int Platform_ThemeOverlay_AppCompat = 2131361941;
+			// aapt resource value: 0x7f0b002b
+			public static int Base_Widget_AppCompat_ProgressBar = 2131427371;
 			
-			// aapt resource value: 0x7f0a0096
-			public static int Platform_ThemeOverlay_AppCompat_Dark = 2131361942;
+			// aapt resource value: 0x7f0b002c
+			public static int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131427372;
 			
-			// aapt resource value: 0x7f0a0097
-			public static int Platform_ThemeOverlay_AppCompat_Light = 2131361943;
+			// aapt resource value: 0x7f0b0089
+			public static int Base_Widget_AppCompat_RatingBar = 2131427465;
 			
-			// aapt resource value: 0x7f0a0034
-			public static int Platform_V11_AppCompat = 2131361844;
+			// aapt resource value: 0x7f0b009a
+			public static int Base_Widget_AppCompat_RatingBar_Indicator = 2131427482;
 			
-			// aapt resource value: 0x7f0a0035
-			public static int Platform_V11_AppCompat_Light = 2131361845;
+			// aapt resource value: 0x7f0b009b
+			public static int Base_Widget_AppCompat_RatingBar_Small = 2131427483;
 			
-			// aapt resource value: 0x7f0a003c
-			public static int Platform_V14_AppCompat = 2131361852;
+			// aapt resource value: 0x7f0b00d3
+			public static int Base_Widget_AppCompat_SearchView = 2131427539;
 			
-			// aapt resource value: 0x7f0a003d
-			public static int Platform_V14_AppCompat_Light = 2131361853;
+			// aapt resource value: 0x7f0b00d4
+			public static int Base_Widget_AppCompat_SearchView_ActionBar = 2131427540;
 			
-			// aapt resource value: 0x7f0a0036
-			public static int Platform_Widget_AppCompat_Spinner = 2131361846;
+			// aapt resource value: 0x7f0b008a
+			public static int Base_Widget_AppCompat_SeekBar = 2131427466;
 			
-			// aapt resource value: 0x7f0a0043
-			public static int RtlOverlay_DialogWindowTitle_AppCompat = 2131361859;
+			// aapt resource value: 0x7f0b00d5
+			public static int Base_Widget_AppCompat_SeekBar_Discrete = 2131427541;
 			
-			// aapt resource value: 0x7f0a0044
-			public static int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131361860;
+			// aapt resource value: 0x7f0b008b
+			public static int Base_Widget_AppCompat_Spinner = 2131427467;
 			
-			// aapt resource value: 0x7f0a0045
-			public static int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131361861;
+			// aapt resource value: 0x7f0b0012
+			public static int Base_Widget_AppCompat_Spinner_Underlined = 2131427346;
 			
-			// aapt resource value: 0x7f0a0046
-			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131361862;
+			// aapt resource value: 0x7f0b008c
+			public static int Base_Widget_AppCompat_TextView_SpinnerItem = 2131427468;
 			
-			// aapt resource value: 0x7f0a0047
-			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131361863;
+			// aapt resource value: 0x7f0b00a3
+			public static int Base_Widget_AppCompat_Toolbar = 2131427491;
 			
-			// aapt resource value: 0x7f0a0048
-			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131361864;
+			// aapt resource value: 0x7f0b008d
+			public static int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131427469;
 			
-			// aapt resource value: 0x7f0a0049
-			public static int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131361865;
+			// aapt resource value: 0x7f0b016c
+			public static int Base_Widget_Design_AppBarLayout = 2131427692;
 			
-			// aapt resource value: 0x7f0a004a
-			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131361866;
+			// aapt resource value: 0x7f0b0170
+			public static int Base_Widget_Design_TabLayout = 2131427696;
 			
-			// aapt resource value: 0x7f0a004b
-			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131361867;
+			// aapt resource value: 0x7f0b000b
+			public static int CardView = 2131427339;
 			
-			// aapt resource value: 0x7f0a004c
-			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131361868;
+			// aapt resource value: 0x7f0b000d
+			public static int CardView_Dark = 2131427341;
 			
-			// aapt resource value: 0x7f0a004d
-			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131361869;
+			// aapt resource value: 0x7f0b000e
+			public static int CardView_Light = 2131427342;
 			
-			// aapt resource value: 0x7f0a004e
-			public static int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131361870;
+			// aapt resource value: 0x7f0b002d
+			public static int Platform_AppCompat = 2131427373;
 			
-			// aapt resource value: 0x7f0a004f
-			public static int RtlUnderlay_Widget_AppCompat_ActionButton = 2131361871;
+			// aapt resource value: 0x7f0b002e
+			public static int Platform_AppCompat_Light = 2131427374;
 			
-			// aapt resource value: 0x7f0a0050
-			public static int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131361872;
+			// aapt resource value: 0x7f0b008e
+			public static int Platform_ThemeOverlay_AppCompat = 2131427470;
 			
-			// aapt resource value: 0x7f0a00d1
-			public static int TextAppearance_AppCompat = 2131362001;
+			// aapt resource value: 0x7f0b008f
+			public static int Platform_ThemeOverlay_AppCompat_Dark = 2131427471;
 			
-			// aapt resource value: 0x7f0a00d2
-			public static int TextAppearance_AppCompat_Body1 = 2131362002;
+			// aapt resource value: 0x7f0b0090
+			public static int Platform_ThemeOverlay_AppCompat_Light = 2131427472;
 			
-			// aapt resource value: 0x7f0a00d3
-			public static int TextAppearance_AppCompat_Body2 = 2131362003;
+			// aapt resource value: 0x7f0b002f
+			public static int Platform_V11_AppCompat = 2131427375;
 			
-			// aapt resource value: 0x7f0a00d4
-			public static int TextAppearance_AppCompat_Button = 2131362004;
+			// aapt resource value: 0x7f0b0030
+			public static int Platform_V11_AppCompat_Light = 2131427376;
 			
-			// aapt resource value: 0x7f0a00d5
-			public static int TextAppearance_AppCompat_Caption = 2131362005;
+			// aapt resource value: 0x7f0b0037
+			public static int Platform_V14_AppCompat = 2131427383;
 			
-			// aapt resource value: 0x7f0a00d6
-			public static int TextAppearance_AppCompat_Display1 = 2131362006;
+			// aapt resource value: 0x7f0b0038
+			public static int Platform_V14_AppCompat_Light = 2131427384;
 			
-			// aapt resource value: 0x7f0a00d7
-			public static int TextAppearance_AppCompat_Display2 = 2131362007;
+			// aapt resource value: 0x7f0b0091
+			public static int Platform_V21_AppCompat = 2131427473;
 			
-			// aapt resource value: 0x7f0a00d8
-			public static int TextAppearance_AppCompat_Display3 = 2131362008;
+			// aapt resource value: 0x7f0b0092
+			public static int Platform_V21_AppCompat_Light = 2131427474;
 			
-			// aapt resource value: 0x7f0a00d9
-			public static int TextAppearance_AppCompat_Display4 = 2131362009;
+			// aapt resource value: 0x7f0b009e
+			public static int Platform_V25_AppCompat = 2131427486;
 			
-			// aapt resource value: 0x7f0a00da
-			public static int TextAppearance_AppCompat_Headline = 2131362010;
+			// aapt resource value: 0x7f0b009f
+			public static int Platform_V25_AppCompat_Light = 2131427487;
 			
-			// aapt resource value: 0x7f0a00db
-			public static int TextAppearance_AppCompat_Inverse = 2131362011;
+			// aapt resource value: 0x7f0b0031
+			public static int Platform_Widget_AppCompat_Spinner = 2131427377;
 			
-			// aapt resource value: 0x7f0a00dc
-			public static int TextAppearance_AppCompat_Large = 2131362012;
+			// aapt resource value: 0x7f0b003a
+			public static int RtlOverlay_DialogWindowTitle_AppCompat = 2131427386;
 			
-			// aapt resource value: 0x7f0a00dd
-			public static int TextAppearance_AppCompat_Large_Inverse = 2131362013;
+			// aapt resource value: 0x7f0b003b
+			public static int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131427387;
 			
-			// aapt resource value: 0x7f0a00de
-			public static int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131362014;
+			// aapt resource value: 0x7f0b003c
+			public static int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131427388;
 			
-			// aapt resource value: 0x7f0a00df
-			public static int TextAppearance_AppCompat_Light_SearchResult_Title = 2131362015;
+			// aapt resource value: 0x7f0b003d
+			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131427389;
 			
-			// aapt resource value: 0x7f0a00e0
-			public static int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131362016;
+			// aapt resource value: 0x7f0b003e
+			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131427390;
 			
-			// aapt resource value: 0x7f0a00e1
-			public static int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131362017;
+			// aapt resource value: 0x7f0b003f
+			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131427391;
 			
-			// aapt resource value: 0x7f0a00e2
-			public static int TextAppearance_AppCompat_Medium = 2131362018;
+			// aapt resource value: 0x7f0b0040
+			public static int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131427392;
 			
-			// aapt resource value: 0x7f0a00e3
-			public static int TextAppearance_AppCompat_Medium_Inverse = 2131362019;
+			// aapt resource value: 0x7f0b0041
+			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131427393;
 			
-			// aapt resource value: 0x7f0a00e4
-			public static int TextAppearance_AppCompat_Menu = 2131362020;
+			// aapt resource value: 0x7f0b0042
+			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131427394;
 			
-			// aapt resource value: 0x7f0a00e5
-			public static int TextAppearance_AppCompat_SearchResult_Subtitle = 2131362021;
+			// aapt resource value: 0x7f0b0043
+			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131427395;
 			
-			// aapt resource value: 0x7f0a00e6
-			public static int TextAppearance_AppCompat_SearchResult_Title = 2131362022;
+			// aapt resource value: 0x7f0b0044
+			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131427396;
 			
-			// aapt resource value: 0x7f0a00e7
-			public static int TextAppearance_AppCompat_Small = 2131362023;
+			// aapt resource value: 0x7f0b0045
+			public static int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131427397;
 			
-			// aapt resource value: 0x7f0a00e8
-			public static int TextAppearance_AppCompat_Small_Inverse = 2131362024;
+			// aapt resource value: 0x7f0b0046
+			public static int RtlUnderlay_Widget_AppCompat_ActionButton = 2131427398;
 			
-			// aapt resource value: 0x7f0a00e9
-			public static int TextAppearance_AppCompat_Subhead = 2131362025;
+			// aapt resource value: 0x7f0b0047
+			public static int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131427399;
 			
-			// aapt resource value: 0x7f0a00ea
-			public static int TextAppearance_AppCompat_Subhead_Inverse = 2131362026;
+			// aapt resource value: 0x7f0b00d6
+			public static int TextAppearance_AppCompat = 2131427542;
 			
-			// aapt resource value: 0x7f0a00eb
-			public static int TextAppearance_AppCompat_Title = 2131362027;
+			// aapt resource value: 0x7f0b00d7
+			public static int TextAppearance_AppCompat_Body1 = 2131427543;
 			
-			// aapt resource value: 0x7f0a00ec
-			public static int TextAppearance_AppCompat_Title_Inverse = 2131362028;
+			// aapt resource value: 0x7f0b00d8
+			public static int TextAppearance_AppCompat_Body2 = 2131427544;
 			
-			// aapt resource value: 0x7f0a00ed
-			public static int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131362029;
+			// aapt resource value: 0x7f0b00d9
+			public static int TextAppearance_AppCompat_Button = 2131427545;
 			
-			// aapt resource value: 0x7f0a00ee
-			public static int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131362030;
+			// aapt resource value: 0x7f0b00da
+			public static int TextAppearance_AppCompat_Caption = 2131427546;
 			
-			// aapt resource value: 0x7f0a00ef
-			public static int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131362031;
+			// aapt resource value: 0x7f0b00db
+			public static int TextAppearance_AppCompat_Display1 = 2131427547;
 			
-			// aapt resource value: 0x7f0a00f0
-			public static int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131362032;
+			// aapt resource value: 0x7f0b00dc
+			public static int TextAppearance_AppCompat_Display2 = 2131427548;
 			
-			// aapt resource value: 0x7f0a00f1
-			public static int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131362033;
+			// aapt resource value: 0x7f0b00dd
+			public static int TextAppearance_AppCompat_Display3 = 2131427549;
 			
-			// aapt resource value: 0x7f0a00f2
-			public static int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131362034;
+			// aapt resource value: 0x7f0b00de
+			public static int TextAppearance_AppCompat_Display4 = 2131427550;
 			
-			// aapt resource value: 0x7f0a00f3
-			public static int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131362035;
+			// aapt resource value: 0x7f0b00df
+			public static int TextAppearance_AppCompat_Headline = 2131427551;
 			
-			// aapt resource value: 0x7f0a00f4
-			public static int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131362036;
+			// aapt resource value: 0x7f0b00e0
+			public static int TextAppearance_AppCompat_Inverse = 2131427552;
 			
-			// aapt resource value: 0x7f0a00f5
-			public static int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131362037;
+			// aapt resource value: 0x7f0b00e1
+			public static int TextAppearance_AppCompat_Large = 2131427553;
 			
-			// aapt resource value: 0x7f0a00f6
-			public static int TextAppearance_AppCompat_Widget_Button = 2131362038;
+			// aapt resource value: 0x7f0b00e2
+			public static int TextAppearance_AppCompat_Large_Inverse = 2131427554;
 			
-			// aapt resource value: 0x7f0a00f7
-			public static int TextAppearance_AppCompat_Widget_Button_Inverse = 2131362039;
+			// aapt resource value: 0x7f0b00e3
+			public static int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131427555;
 			
-			// aapt resource value: 0x7f0a00f8
-			public static int TextAppearance_AppCompat_Widget_DropDownItem = 2131362040;
+			// aapt resource value: 0x7f0b00e4
+			public static int TextAppearance_AppCompat_Light_SearchResult_Title = 2131427556;
 			
-			// aapt resource value: 0x7f0a00f9
-			public static int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131362041;
+			// aapt resource value: 0x7f0b00e5
+			public static int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131427557;
 			
-			// aapt resource value: 0x7f0a00fa
-			public static int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131362042;
+			// aapt resource value: 0x7f0b00e6
+			public static int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131427558;
 			
-			// aapt resource value: 0x7f0a00fb
-			public static int TextAppearance_AppCompat_Widget_Switch = 2131362043;
+			// aapt resource value: 0x7f0b00e7
+			public static int TextAppearance_AppCompat_Medium = 2131427559;
 			
-			// aapt resource value: 0x7f0a00fc
-			public static int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131362044;
+			// aapt resource value: 0x7f0b00e8
+			public static int TextAppearance_AppCompat_Medium_Inverse = 2131427560;
 			
-			// aapt resource value: 0x7f0a015c
-			public static int TextAppearance_Design_CollapsingToolbar_Expanded = 2131362140;
+			// aapt resource value: 0x7f0b00e9
+			public static int TextAppearance_AppCompat_Menu = 2131427561;
 			
-			// aapt resource value: 0x7f0a015d
-			public static int TextAppearance_Design_Counter = 2131362141;
+			// aapt resource value: 0x7f0b00ea
+			public static int TextAppearance_AppCompat_SearchResult_Subtitle = 2131427562;
 			
-			// aapt resource value: 0x7f0a015e
-			public static int TextAppearance_Design_Counter_Overflow = 2131362142;
+			// aapt resource value: 0x7f0b00eb
+			public static int TextAppearance_AppCompat_SearchResult_Title = 2131427563;
 			
-			// aapt resource value: 0x7f0a015f
-			public static int TextAppearance_Design_Error = 2131362143;
+			// aapt resource value: 0x7f0b00ec
+			public static int TextAppearance_AppCompat_Small = 2131427564;
 			
-			// aapt resource value: 0x7f0a0160
-			public static int TextAppearance_Design_Hint = 2131362144;
+			// aapt resource value: 0x7f0b00ed
+			public static int TextAppearance_AppCompat_Small_Inverse = 2131427565;
 			
-			// aapt resource value: 0x7f0a0161
-			public static int TextAppearance_Design_Snackbar_Message = 2131362145;
+			// aapt resource value: 0x7f0b00ee
+			public static int TextAppearance_AppCompat_Subhead = 2131427566;
 			
-			// aapt resource value: 0x7f0a0162
-			public static int TextAppearance_Design_Tab = 2131362146;
+			// aapt resource value: 0x7f0b00ef
+			public static int TextAppearance_AppCompat_Subhead_Inverse = 2131427567;
 			
-			// aapt resource value: 0x7f0a003e
-			public static int TextAppearance_StatusBar_EventContent = 2131361854;
+			// aapt resource value: 0x7f0b00f0
+			public static int TextAppearance_AppCompat_Title = 2131427568;
 			
-			// aapt resource value: 0x7f0a003f
-			public static int TextAppearance_StatusBar_EventContent_Info = 2131361855;
+			// aapt resource value: 0x7f0b00f1
+			public static int TextAppearance_AppCompat_Title_Inverse = 2131427569;
 			
-			// aapt resource value: 0x7f0a0040
-			public static int TextAppearance_StatusBar_EventContent_Line2 = 2131361856;
+			// aapt resource value: 0x7f0b0039
+			public static int TextAppearance_AppCompat_Tooltip = 2131427385;
 			
-			// aapt resource value: 0x7f0a0041
-			public static int TextAppearance_StatusBar_EventContent_Time = 2131361857;
+			// aapt resource value: 0x7f0b00f2
+			public static int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131427570;
 			
-			// aapt resource value: 0x7f0a0042
-			public static int TextAppearance_StatusBar_EventContent_Title = 2131361858;
+			// aapt resource value: 0x7f0b00f3
+			public static int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131427571;
 			
-			// aapt resource value: 0x7f0a00fd
-			public static int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131362045;
+			// aapt resource value: 0x7f0b00f4
+			public static int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131427572;
 			
-			// aapt resource value: 0x7f0a00fe
-			public static int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131362046;
+			// aapt resource value: 0x7f0b00f5
+			public static int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131427573;
 			
-			// aapt resource value: 0x7f0a00ff
-			public static int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131362047;
+			// aapt resource value: 0x7f0b00f6
+			public static int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131427574;
 			
-			// aapt resource value: 0x7f0a0100
-			public static int Theme_AppCompat = 2131362048;
+			// aapt resource value: 0x7f0b00f7
+			public static int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131427575;
 			
-			// aapt resource value: 0x7f0a0101
-			public static int Theme_AppCompat_CompactMenu = 2131362049;
+			// aapt resource value: 0x7f0b00f8
+			public static int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131427576;
 			
-			// aapt resource value: 0x7f0a001f
-			public static int Theme_AppCompat_DayNight = 2131361823;
+			// aapt resource value: 0x7f0b00f9
+			public static int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131427577;
 			
-			// aapt resource value: 0x7f0a0020
-			public static int Theme_AppCompat_DayNight_DarkActionBar = 2131361824;
+			// aapt resource value: 0x7f0b00fa
+			public static int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131427578;
 			
-			// aapt resource value: 0x7f0a0021
-			public static int Theme_AppCompat_DayNight_Dialog = 2131361825;
+			// aapt resource value: 0x7f0b00fb
+			public static int TextAppearance_AppCompat_Widget_Button = 2131427579;
 			
-			// aapt resource value: 0x7f0a0022
-			public static int Theme_AppCompat_DayNight_Dialog_Alert = 2131361826;
+			// aapt resource value: 0x7f0b00fc
+			public static int TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131427580;
 			
-			// aapt resource value: 0x7f0a0023
-			public static int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131361827;
+			// aapt resource value: 0x7f0b00fd
+			public static int TextAppearance_AppCompat_Widget_Button_Colored = 2131427581;
 			
-			// aapt resource value: 0x7f0a0024
-			public static int Theme_AppCompat_DayNight_DialogWhenLarge = 2131361828;
+			// aapt resource value: 0x7f0b00fe
+			public static int TextAppearance_AppCompat_Widget_Button_Inverse = 2131427582;
 			
-			// aapt resource value: 0x7f0a0025
-			public static int Theme_AppCompat_DayNight_NoActionBar = 2131361829;
+			// aapt resource value: 0x7f0b00ff
+			public static int TextAppearance_AppCompat_Widget_DropDownItem = 2131427583;
 			
-			// aapt resource value: 0x7f0a0102
-			public static int Theme_AppCompat_Dialog = 2131362050;
+			// aapt resource value: 0x7f0b0100
+			public static int TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131427584;
 			
-			// aapt resource value: 0x7f0a0103
-			public static int Theme_AppCompat_Dialog_Alert = 2131362051;
+			// aapt resource value: 0x7f0b0101
+			public static int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131427585;
 			
-			// aapt resource value: 0x7f0a0104
-			public static int Theme_AppCompat_Dialog_MinWidth = 2131362052;
+			// aapt resource value: 0x7f0b0102
+			public static int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131427586;
 			
-			// aapt resource value: 0x7f0a0105
-			public static int Theme_AppCompat_DialogWhenLarge = 2131362053;
+			// aapt resource value: 0x7f0b0103
+			public static int TextAppearance_AppCompat_Widget_Switch = 2131427587;
 			
-			// aapt resource value: 0x7f0a0106
-			public static int Theme_AppCompat_Light = 2131362054;
+			// aapt resource value: 0x7f0b0104
+			public static int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131427588;
 			
-			// aapt resource value: 0x7f0a0107
-			public static int Theme_AppCompat_Light_DarkActionBar = 2131362055;
+			// aapt resource value: 0x7f0b0188
+			public static int TextAppearance_Compat_Notification = 2131427720;
 			
-			// aapt resource value: 0x7f0a0108
-			public static int Theme_AppCompat_Light_Dialog = 2131362056;
+			// aapt resource value: 0x7f0b0189
+			public static int TextAppearance_Compat_Notification_Info = 2131427721;
 			
-			// aapt resource value: 0x7f0a0109
-			public static int Theme_AppCompat_Light_Dialog_Alert = 2131362057;
+			// aapt resource value: 0x7f0b0165
+			public static int TextAppearance_Compat_Notification_Info_Media = 2131427685;
 			
-			// aapt resource value: 0x7f0a010a
-			public static int Theme_AppCompat_Light_Dialog_MinWidth = 2131362058;
+			// aapt resource value: 0x7f0b018e
+			public static int TextAppearance_Compat_Notification_Line2 = 2131427726;
 			
-			// aapt resource value: 0x7f0a010b
-			public static int Theme_AppCompat_Light_DialogWhenLarge = 2131362059;
+			// aapt resource value: 0x7f0b0169
+			public static int TextAppearance_Compat_Notification_Line2_Media = 2131427689;
 			
-			// aapt resource value: 0x7f0a010c
-			public static int Theme_AppCompat_Light_NoActionBar = 2131362060;
+			// aapt resource value: 0x7f0b0166
+			public static int TextAppearance_Compat_Notification_Media = 2131427686;
 			
-			// aapt resource value: 0x7f0a010d
-			public static int Theme_AppCompat_NoActionBar = 2131362061;
+			// aapt resource value: 0x7f0b018a
+			public static int TextAppearance_Compat_Notification_Time = 2131427722;
 			
-			// aapt resource value: 0x7f0a0163
-			public static int Theme_Design = 2131362147;
+			// aapt resource value: 0x7f0b0167
+			public static int TextAppearance_Compat_Notification_Time_Media = 2131427687;
 			
-			// aapt resource value: 0x7f0a0164
-			public static int Theme_Design_BottomSheetDialog = 2131362148;
+			// aapt resource value: 0x7f0b018b
+			public static int TextAppearance_Compat_Notification_Title = 2131427723;
 			
-			// aapt resource value: 0x7f0a0165
-			public static int Theme_Design_Light = 2131362149;
+			// aapt resource value: 0x7f0b0168
+			public static int TextAppearance_Compat_Notification_Title_Media = 2131427688;
 			
-			// aapt resource value: 0x7f0a0166
-			public static int Theme_Design_Light_BottomSheetDialog = 2131362150;
+			// aapt resource value: 0x7f0b0171
+			public static int TextAppearance_Design_CollapsingToolbar_Expanded = 2131427697;
 			
-			// aapt resource value: 0x7f0a0167
-			public static int Theme_Design_Light_NoActionBar = 2131362151;
+			// aapt resource value: 0x7f0b0172
+			public static int TextAppearance_Design_Counter = 2131427698;
 			
-			// aapt resource value: 0x7f0a0168
-			public static int Theme_Design_NoActionBar = 2131362152;
+			// aapt resource value: 0x7f0b0173
+			public static int TextAppearance_Design_Counter_Overflow = 2131427699;
 			
-			// aapt resource value: 0x7f0a0000
-			public static int Theme_MediaRouter = 2131361792;
+			// aapt resource value: 0x7f0b0174
+			public static int TextAppearance_Design_Error = 2131427700;
 			
-			// aapt resource value: 0x7f0a0001
-			public static int Theme_MediaRouter_Light = 2131361793;
+			// aapt resource value: 0x7f0b0175
+			public static int TextAppearance_Design_Hint = 2131427701;
 			
-			// aapt resource value: 0x7f0a0002
-			public static int Theme_MediaRouter_Light_DarkControlPanel = 2131361794;
+			// aapt resource value: 0x7f0b0176
+			public static int TextAppearance_Design_Snackbar_Message = 2131427702;
 			
-			// aapt resource value: 0x7f0a0003
-			public static int Theme_MediaRouter_LightControlPanel = 2131361795;
+			// aapt resource value: 0x7f0b0177
+			public static int TextAppearance_Design_Tab = 2131427703;
 			
-			// aapt resource value: 0x7f0a010e
-			public static int ThemeOverlay_AppCompat = 2131362062;
+			// aapt resource value: 0x7f0b0000
+			public static int TextAppearance_MediaRouter_PrimaryText = 2131427328;
 			
-			// aapt resource value: 0x7f0a010f
-			public static int ThemeOverlay_AppCompat_ActionBar = 2131362063;
+			// aapt resource value: 0x7f0b0001
+			public static int TextAppearance_MediaRouter_SecondaryText = 2131427329;
 			
-			// aapt resource value: 0x7f0a0110
-			public static int ThemeOverlay_AppCompat_Dark = 2131362064;
+			// aapt resource value: 0x7f0b0002
+			public static int TextAppearance_MediaRouter_Title = 2131427330;
 			
-			// aapt resource value: 0x7f0a0111
-			public static int ThemeOverlay_AppCompat_Dark_ActionBar = 2131362065;
+			// aapt resource value: 0x7f0b0105
+			public static int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131427589;
 			
-			// aapt resource value: 0x7f0a0112
-			public static int ThemeOverlay_AppCompat_Light = 2131362066;
+			// aapt resource value: 0x7f0b0106
+			public static int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131427590;
 			
-			// aapt resource value: 0x7f0a0113
-			public static int Widget_AppCompat_ActionBar = 2131362067;
+			// aapt resource value: 0x7f0b0107
+			public static int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131427591;
 			
-			// aapt resource value: 0x7f0a0114
-			public static int Widget_AppCompat_ActionBar_Solid = 2131362068;
+			// aapt resource value: 0x7f0b0108
+			public static int Theme_AppCompat = 2131427592;
 			
-			// aapt resource value: 0x7f0a0115
-			public static int Widget_AppCompat_ActionBar_TabBar = 2131362069;
+			// aapt resource value: 0x7f0b0109
+			public static int Theme_AppCompat_CompactMenu = 2131427593;
 			
-			// aapt resource value: 0x7f0a0116
-			public static int Widget_AppCompat_ActionBar_TabText = 2131362070;
+			// aapt resource value: 0x7f0b0013
+			public static int Theme_AppCompat_DayNight = 2131427347;
 			
-			// aapt resource value: 0x7f0a0117
-			public static int Widget_AppCompat_ActionBar_TabView = 2131362071;
+			// aapt resource value: 0x7f0b0014
+			public static int Theme_AppCompat_DayNight_DarkActionBar = 2131427348;
 			
-			// aapt resource value: 0x7f0a0118
-			public static int Widget_AppCompat_ActionButton = 2131362072;
+			// aapt resource value: 0x7f0b0015
+			public static int Theme_AppCompat_DayNight_Dialog = 2131427349;
 			
-			// aapt resource value: 0x7f0a0119
-			public static int Widget_AppCompat_ActionButton_CloseMode = 2131362073;
+			// aapt resource value: 0x7f0b0016
+			public static int Theme_AppCompat_DayNight_Dialog_Alert = 2131427350;
 			
-			// aapt resource value: 0x7f0a011a
-			public static int Widget_AppCompat_ActionButton_Overflow = 2131362074;
+			// aapt resource value: 0x7f0b0017
+			public static int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131427351;
 			
-			// aapt resource value: 0x7f0a011b
-			public static int Widget_AppCompat_ActionMode = 2131362075;
+			// aapt resource value: 0x7f0b0018
+			public static int Theme_AppCompat_DayNight_DialogWhenLarge = 2131427352;
 			
-			// aapt resource value: 0x7f0a011c
-			public static int Widget_AppCompat_ActivityChooserView = 2131362076;
+			// aapt resource value: 0x7f0b0019
+			public static int Theme_AppCompat_DayNight_NoActionBar = 2131427353;
 			
-			// aapt resource value: 0x7f0a011d
-			public static int Widget_AppCompat_AutoCompleteTextView = 2131362077;
+			// aapt resource value: 0x7f0b010a
+			public static int Theme_AppCompat_Dialog = 2131427594;
 			
-			// aapt resource value: 0x7f0a011e
-			public static int Widget_AppCompat_Button = 2131362078;
+			// aapt resource value: 0x7f0b010b
+			public static int Theme_AppCompat_Dialog_Alert = 2131427595;
 			
-			// aapt resource value: 0x7f0a011f
-			public static int Widget_AppCompat_Button_Borderless = 2131362079;
+			// aapt resource value: 0x7f0b010c
+			public static int Theme_AppCompat_Dialog_MinWidth = 2131427596;
 			
-			// aapt resource value: 0x7f0a0120
-			public static int Widget_AppCompat_Button_Borderless_Colored = 2131362080;
+			// aapt resource value: 0x7f0b010d
+			public static int Theme_AppCompat_DialogWhenLarge = 2131427597;
 			
-			// aapt resource value: 0x7f0a0121
-			public static int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131362081;
+			// aapt resource value: 0x7f0b010e
+			public static int Theme_AppCompat_Light = 2131427598;
 			
-			// aapt resource value: 0x7f0a0122
-			public static int Widget_AppCompat_Button_Colored = 2131362082;
+			// aapt resource value: 0x7f0b010f
+			public static int Theme_AppCompat_Light_DarkActionBar = 2131427599;
 			
-			// aapt resource value: 0x7f0a0123
-			public static int Widget_AppCompat_Button_Small = 2131362083;
+			// aapt resource value: 0x7f0b0110
+			public static int Theme_AppCompat_Light_Dialog = 2131427600;
 			
-			// aapt resource value: 0x7f0a0124
-			public static int Widget_AppCompat_ButtonBar = 2131362084;
+			// aapt resource value: 0x7f0b0111
+			public static int Theme_AppCompat_Light_Dialog_Alert = 2131427601;
 			
-			// aapt resource value: 0x7f0a0125
-			public static int Widget_AppCompat_ButtonBar_AlertDialog = 2131362085;
+			// aapt resource value: 0x7f0b0112
+			public static int Theme_AppCompat_Light_Dialog_MinWidth = 2131427602;
 			
-			// aapt resource value: 0x7f0a0126
-			public static int Widget_AppCompat_CompoundButton_CheckBox = 2131362086;
+			// aapt resource value: 0x7f0b0113
+			public static int Theme_AppCompat_Light_DialogWhenLarge = 2131427603;
 			
-			// aapt resource value: 0x7f0a0127
-			public static int Widget_AppCompat_CompoundButton_RadioButton = 2131362087;
+			// aapt resource value: 0x7f0b0114
+			public static int Theme_AppCompat_Light_NoActionBar = 2131427604;
 			
-			// aapt resource value: 0x7f0a0128
-			public static int Widget_AppCompat_CompoundButton_Switch = 2131362088;
+			// aapt resource value: 0x7f0b0115
+			public static int Theme_AppCompat_NoActionBar = 2131427605;
 			
-			// aapt resource value: 0x7f0a0129
-			public static int Widget_AppCompat_DrawerArrowToggle = 2131362089;
+			// aapt resource value: 0x7f0b0178
+			public static int Theme_Design = 2131427704;
 			
-			// aapt resource value: 0x7f0a012a
-			public static int Widget_AppCompat_DropDownItem_Spinner = 2131362090;
+			// aapt resource value: 0x7f0b0179
+			public static int Theme_Design_BottomSheetDialog = 2131427705;
 			
-			// aapt resource value: 0x7f0a012b
-			public static int Widget_AppCompat_EditText = 2131362091;
+			// aapt resource value: 0x7f0b017a
+			public static int Theme_Design_Light = 2131427706;
 			
-			// aapt resource value: 0x7f0a012c
-			public static int Widget_AppCompat_ImageButton = 2131362092;
+			// aapt resource value: 0x7f0b017b
+			public static int Theme_Design_Light_BottomSheetDialog = 2131427707;
 			
-			// aapt resource value: 0x7f0a012d
-			public static int Widget_AppCompat_Light_ActionBar = 2131362093;
+			// aapt resource value: 0x7f0b017c
+			public static int Theme_Design_Light_NoActionBar = 2131427708;
 			
-			// aapt resource value: 0x7f0a012e
-			public static int Widget_AppCompat_Light_ActionBar_Solid = 2131362094;
+			// aapt resource value: 0x7f0b017d
+			public static int Theme_Design_NoActionBar = 2131427709;
 			
-			// aapt resource value: 0x7f0a012f
-			public static int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131362095;
+			// aapt resource value: 0x7f0b0003
+			public static int Theme_MediaRouter = 2131427331;
 			
-			// aapt resource value: 0x7f0a0130
-			public static int Widget_AppCompat_Light_ActionBar_TabBar = 2131362096;
+			// aapt resource value: 0x7f0b0004
+			public static int Theme_MediaRouter_Light = 2131427332;
 			
-			// aapt resource value: 0x7f0a0131
-			public static int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131362097;
+			// aapt resource value: 0x7f0b0005
+			public static int Theme_MediaRouter_Light_DarkControlPanel = 2131427333;
 			
-			// aapt resource value: 0x7f0a0132
-			public static int Widget_AppCompat_Light_ActionBar_TabText = 2131362098;
+			// aapt resource value: 0x7f0b0006
+			public static int Theme_MediaRouter_LightControlPanel = 2131427334;
 			
-			// aapt resource value: 0x7f0a0133
-			public static int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131362099;
+			// aapt resource value: 0x7f0b0116
+			public static int ThemeOverlay_AppCompat = 2131427606;
 			
-			// aapt resource value: 0x7f0a0134
-			public static int Widget_AppCompat_Light_ActionBar_TabView = 2131362100;
+			// aapt resource value: 0x7f0b0117
+			public static int ThemeOverlay_AppCompat_ActionBar = 2131427607;
 			
-			// aapt resource value: 0x7f0a0135
-			public static int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131362101;
+			// aapt resource value: 0x7f0b0118
+			public static int ThemeOverlay_AppCompat_Dark = 2131427608;
 			
-			// aapt resource value: 0x7f0a0136
-			public static int Widget_AppCompat_Light_ActionButton = 2131362102;
+			// aapt resource value: 0x7f0b0119
+			public static int ThemeOverlay_AppCompat_Dark_ActionBar = 2131427609;
 			
-			// aapt resource value: 0x7f0a0137
-			public static int Widget_AppCompat_Light_ActionButton_CloseMode = 2131362103;
+			// aapt resource value: 0x7f0b011a
+			public static int ThemeOverlay_AppCompat_Dialog = 2131427610;
 			
-			// aapt resource value: 0x7f0a0138
-			public static int Widget_AppCompat_Light_ActionButton_Overflow = 2131362104;
+			// aapt resource value: 0x7f0b011b
+			public static int ThemeOverlay_AppCompat_Dialog_Alert = 2131427611;
 			
-			// aapt resource value: 0x7f0a0139
-			public static int Widget_AppCompat_Light_ActionMode_Inverse = 2131362105;
+			// aapt resource value: 0x7f0b011c
+			public static int ThemeOverlay_AppCompat_Light = 2131427612;
 			
-			// aapt resource value: 0x7f0a013a
-			public static int Widget_AppCompat_Light_ActivityChooserView = 2131362106;
+			// aapt resource value: 0x7f0b0007
+			public static int ThemeOverlay_MediaRouter_Dark = 2131427335;
 			
-			// aapt resource value: 0x7f0a013b
-			public static int Widget_AppCompat_Light_AutoCompleteTextView = 2131362107;
+			// aapt resource value: 0x7f0b0008
+			public static int ThemeOverlay_MediaRouter_Light = 2131427336;
 			
-			// aapt resource value: 0x7f0a013c
-			public static int Widget_AppCompat_Light_DropDownItem_Spinner = 2131362108;
+			// aapt resource value: 0x7f0b011d
+			public static int Widget_AppCompat_ActionBar = 2131427613;
 			
-			// aapt resource value: 0x7f0a013d
-			public static int Widget_AppCompat_Light_ListPopupWindow = 2131362109;
+			// aapt resource value: 0x7f0b011e
+			public static int Widget_AppCompat_ActionBar_Solid = 2131427614;
 			
-			// aapt resource value: 0x7f0a013e
-			public static int Widget_AppCompat_Light_ListView_DropDown = 2131362110;
+			// aapt resource value: 0x7f0b011f
+			public static int Widget_AppCompat_ActionBar_TabBar = 2131427615;
 			
-			// aapt resource value: 0x7f0a013f
-			public static int Widget_AppCompat_Light_PopupMenu = 2131362111;
+			// aapt resource value: 0x7f0b0120
+			public static int Widget_AppCompat_ActionBar_TabText = 2131427616;
 			
-			// aapt resource value: 0x7f0a0140
-			public static int Widget_AppCompat_Light_PopupMenu_Overflow = 2131362112;
+			// aapt resource value: 0x7f0b0121
+			public static int Widget_AppCompat_ActionBar_TabView = 2131427617;
 			
-			// aapt resource value: 0x7f0a0141
-			public static int Widget_AppCompat_Light_SearchView = 2131362113;
+			// aapt resource value: 0x7f0b0122
+			public static int Widget_AppCompat_ActionButton = 2131427618;
 			
-			// aapt resource value: 0x7f0a0142
-			public static int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131362114;
+			// aapt resource value: 0x7f0b0123
+			public static int Widget_AppCompat_ActionButton_CloseMode = 2131427619;
 			
-			// aapt resource value: 0x7f0a0143
-			public static int Widget_AppCompat_ListPopupWindow = 2131362115;
+			// aapt resource value: 0x7f0b0124
+			public static int Widget_AppCompat_ActionButton_Overflow = 2131427620;
 			
-			// aapt resource value: 0x7f0a0144
-			public static int Widget_AppCompat_ListView = 2131362116;
+			// aapt resource value: 0x7f0b0125
+			public static int Widget_AppCompat_ActionMode = 2131427621;
 			
-			// aapt resource value: 0x7f0a0145
-			public static int Widget_AppCompat_ListView_DropDown = 2131362117;
+			// aapt resource value: 0x7f0b0126
+			public static int Widget_AppCompat_ActivityChooserView = 2131427622;
 			
-			// aapt resource value: 0x7f0a0146
-			public static int Widget_AppCompat_ListView_Menu = 2131362118;
+			// aapt resource value: 0x7f0b0127
+			public static int Widget_AppCompat_AutoCompleteTextView = 2131427623;
 			
-			// aapt resource value: 0x7f0a0147
-			public static int Widget_AppCompat_PopupMenu = 2131362119;
+			// aapt resource value: 0x7f0b0128
+			public static int Widget_AppCompat_Button = 2131427624;
 			
-			// aapt resource value: 0x7f0a0148
-			public static int Widget_AppCompat_PopupMenu_Overflow = 2131362120;
+			// aapt resource value: 0x7f0b0129
+			public static int Widget_AppCompat_Button_Borderless = 2131427625;
 			
-			// aapt resource value: 0x7f0a0149
-			public static int Widget_AppCompat_PopupWindow = 2131362121;
+			// aapt resource value: 0x7f0b012a
+			public static int Widget_AppCompat_Button_Borderless_Colored = 2131427626;
 			
-			// aapt resource value: 0x7f0a014a
-			public static int Widget_AppCompat_ProgressBar = 2131362122;
+			// aapt resource value: 0x7f0b012b
+			public static int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131427627;
 			
-			// aapt resource value: 0x7f0a014b
-			public static int Widget_AppCompat_ProgressBar_Horizontal = 2131362123;
+			// aapt resource value: 0x7f0b012c
+			public static int Widget_AppCompat_Button_Colored = 2131427628;
 			
-			// aapt resource value: 0x7f0a014c
-			public static int Widget_AppCompat_RatingBar = 2131362124;
+			// aapt resource value: 0x7f0b012d
+			public static int Widget_AppCompat_Button_Small = 2131427629;
 			
-			// aapt resource value: 0x7f0a014d
-			public static int Widget_AppCompat_RatingBar_Indicator = 2131362125;
+			// aapt resource value: 0x7f0b012e
+			public static int Widget_AppCompat_ButtonBar = 2131427630;
 			
-			// aapt resource value: 0x7f0a014e
-			public static int Widget_AppCompat_RatingBar_Small = 2131362126;
+			// aapt resource value: 0x7f0b012f
+			public static int Widget_AppCompat_ButtonBar_AlertDialog = 2131427631;
 			
-			// aapt resource value: 0x7f0a014f
-			public static int Widget_AppCompat_SearchView = 2131362127;
+			// aapt resource value: 0x7f0b0130
+			public static int Widget_AppCompat_CompoundButton_CheckBox = 2131427632;
 			
-			// aapt resource value: 0x7f0a0150
-			public static int Widget_AppCompat_SearchView_ActionBar = 2131362128;
+			// aapt resource value: 0x7f0b0131
+			public static int Widget_AppCompat_CompoundButton_RadioButton = 2131427633;
 			
-			// aapt resource value: 0x7f0a0151
-			public static int Widget_AppCompat_SeekBar = 2131362129;
+			// aapt resource value: 0x7f0b0132
+			public static int Widget_AppCompat_CompoundButton_Switch = 2131427634;
 			
-			// aapt resource value: 0x7f0a0152
-			public static int Widget_AppCompat_Spinner = 2131362130;
+			// aapt resource value: 0x7f0b0133
+			public static int Widget_AppCompat_DrawerArrowToggle = 2131427635;
 			
-			// aapt resource value: 0x7f0a0153
-			public static int Widget_AppCompat_Spinner_DropDown = 2131362131;
+			// aapt resource value: 0x7f0b0134
+			public static int Widget_AppCompat_DropDownItem_Spinner = 2131427636;
 			
-			// aapt resource value: 0x7f0a0154
-			public static int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131362132;
+			// aapt resource value: 0x7f0b0135
+			public static int Widget_AppCompat_EditText = 2131427637;
 			
-			// aapt resource value: 0x7f0a0155
-			public static int Widget_AppCompat_Spinner_Underlined = 2131362133;
+			// aapt resource value: 0x7f0b0136
+			public static int Widget_AppCompat_ImageButton = 2131427638;
 			
-			// aapt resource value: 0x7f0a0156
-			public static int Widget_AppCompat_TextView_SpinnerItem = 2131362134;
+			// aapt resource value: 0x7f0b0137
+			public static int Widget_AppCompat_Light_ActionBar = 2131427639;
 			
-			// aapt resource value: 0x7f0a0157
-			public static int Widget_AppCompat_Toolbar = 2131362135;
+			// aapt resource value: 0x7f0b0138
+			public static int Widget_AppCompat_Light_ActionBar_Solid = 2131427640;
 			
-			// aapt resource value: 0x7f0a0158
-			public static int Widget_AppCompat_Toolbar_Button_Navigation = 2131362136;
+			// aapt resource value: 0x7f0b0139
+			public static int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131427641;
 			
-			// aapt resource value: 0x7f0a0169
-			public static int Widget_Design_AppBarLayout = 2131362153;
+			// aapt resource value: 0x7f0b013a
+			public static int Widget_AppCompat_Light_ActionBar_TabBar = 2131427642;
 			
-			// aapt resource value: 0x7f0a016a
-			public static int Widget_Design_BottomSheet_Modal = 2131362154;
+			// aapt resource value: 0x7f0b013b
+			public static int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131427643;
 			
-			// aapt resource value: 0x7f0a016b
-			public static int Widget_Design_CollapsingToolbar = 2131362155;
+			// aapt resource value: 0x7f0b013c
+			public static int Widget_AppCompat_Light_ActionBar_TabText = 2131427644;
 			
-			// aapt resource value: 0x7f0a016c
-			public static int Widget_Design_CoordinatorLayout = 2131362156;
+			// aapt resource value: 0x7f0b013d
+			public static int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131427645;
 			
-			// aapt resource value: 0x7f0a016d
-			public static int Widget_Design_FloatingActionButton = 2131362157;
+			// aapt resource value: 0x7f0b013e
+			public static int Widget_AppCompat_Light_ActionBar_TabView = 2131427646;
 			
-			// aapt resource value: 0x7f0a016e
-			public static int Widget_Design_NavigationView = 2131362158;
+			// aapt resource value: 0x7f0b013f
+			public static int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131427647;
 			
-			// aapt resource value: 0x7f0a016f
-			public static int Widget_Design_ScrimInsetsFrameLayout = 2131362159;
+			// aapt resource value: 0x7f0b0140
+			public static int Widget_AppCompat_Light_ActionButton = 2131427648;
 			
-			// aapt resource value: 0x7f0a0170
-			public static int Widget_Design_Snackbar = 2131362160;
+			// aapt resource value: 0x7f0b0141
+			public static int Widget_AppCompat_Light_ActionButton_CloseMode = 2131427649;
 			
-			// aapt resource value: 0x7f0a0159
-			public static int Widget_Design_TabLayout = 2131362137;
+			// aapt resource value: 0x7f0b0142
+			public static int Widget_AppCompat_Light_ActionButton_Overflow = 2131427650;
 			
-			// aapt resource value: 0x7f0a0171
-			public static int Widget_Design_TextInputLayout = 2131362161;
+			// aapt resource value: 0x7f0b0143
+			public static int Widget_AppCompat_Light_ActionMode_Inverse = 2131427651;
 			
-			// aapt resource value: 0x7f0a0004
-			public static int Widget_MediaRouter_ChooserText = 2131361796;
+			// aapt resource value: 0x7f0b0144
+			public static int Widget_AppCompat_Light_ActivityChooserView = 2131427652;
 			
-			// aapt resource value: 0x7f0a0005
-			public static int Widget_MediaRouter_ChooserText_Primary = 2131361797;
+			// aapt resource value: 0x7f0b0145
+			public static int Widget_AppCompat_Light_AutoCompleteTextView = 2131427653;
 			
-			// aapt resource value: 0x7f0a0006
-			public static int Widget_MediaRouter_ChooserText_Primary_Dark = 2131361798;
+			// aapt resource value: 0x7f0b0146
+			public static int Widget_AppCompat_Light_DropDownItem_Spinner = 2131427654;
 			
-			// aapt resource value: 0x7f0a0007
-			public static int Widget_MediaRouter_ChooserText_Primary_Light = 2131361799;
+			// aapt resource value: 0x7f0b0147
+			public static int Widget_AppCompat_Light_ListPopupWindow = 2131427655;
 			
-			// aapt resource value: 0x7f0a0008
-			public static int Widget_MediaRouter_ChooserText_Secondary = 2131361800;
+			// aapt resource value: 0x7f0b0148
+			public static int Widget_AppCompat_Light_ListView_DropDown = 2131427656;
 			
-			// aapt resource value: 0x7f0a0009
-			public static int Widget_MediaRouter_ChooserText_Secondary_Dark = 2131361801;
+			// aapt resource value: 0x7f0b0149
+			public static int Widget_AppCompat_Light_PopupMenu = 2131427657;
 			
-			// aapt resource value: 0x7f0a000a
-			public static int Widget_MediaRouter_ChooserText_Secondary_Light = 2131361802;
+			// aapt resource value: 0x7f0b014a
+			public static int Widget_AppCompat_Light_PopupMenu_Overflow = 2131427658;
 			
-			// aapt resource value: 0x7f0a000b
-			public static int Widget_MediaRouter_ControllerText = 2131361803;
+			// aapt resource value: 0x7f0b014b
+			public static int Widget_AppCompat_Light_SearchView = 2131427659;
 			
-			// aapt resource value: 0x7f0a000c
-			public static int Widget_MediaRouter_ControllerText_Primary = 2131361804;
+			// aapt resource value: 0x7f0b014c
+			public static int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131427660;
 			
-			// aapt resource value: 0x7f0a000d
-			public static int Widget_MediaRouter_ControllerText_Primary_Dark = 2131361805;
+			// aapt resource value: 0x7f0b014d
+			public static int Widget_AppCompat_ListMenuView = 2131427661;
 			
-			// aapt resource value: 0x7f0a000e
-			public static int Widget_MediaRouter_ControllerText_Primary_Light = 2131361806;
+			// aapt resource value: 0x7f0b014e
+			public static int Widget_AppCompat_ListPopupWindow = 2131427662;
 			
-			// aapt resource value: 0x7f0a000f
-			public static int Widget_MediaRouter_ControllerText_Secondary = 2131361807;
+			// aapt resource value: 0x7f0b014f
+			public static int Widget_AppCompat_ListView = 2131427663;
 			
-			// aapt resource value: 0x7f0a0010
-			public static int Widget_MediaRouter_ControllerText_Secondary_Dark = 2131361808;
+			// aapt resource value: 0x7f0b0150
+			public static int Widget_AppCompat_ListView_DropDown = 2131427664;
 			
-			// aapt resource value: 0x7f0a0011
-			public static int Widget_MediaRouter_ControllerText_Secondary_Light = 2131361809;
+			// aapt resource value: 0x7f0b0151
+			public static int Widget_AppCompat_ListView_Menu = 2131427665;
 			
-			// aapt resource value: 0x7f0a0012
-			public static int Widget_MediaRouter_ControllerText_Title = 2131361810;
+			// aapt resource value: 0x7f0b0152
+			public static int Widget_AppCompat_PopupMenu = 2131427666;
 			
-			// aapt resource value: 0x7f0a0013
-			public static int Widget_MediaRouter_ControllerText_Title_Dark = 2131361811;
+			// aapt resource value: 0x7f0b0153
+			public static int Widget_AppCompat_PopupMenu_Overflow = 2131427667;
 			
-			// aapt resource value: 0x7f0a0014
-			public static int Widget_MediaRouter_ControllerText_Title_Light = 2131361812;
+			// aapt resource value: 0x7f0b0154
+			public static int Widget_AppCompat_PopupWindow = 2131427668;
 			
-			// aapt resource value: 0x7f0a0015
-			public static int Widget_MediaRouter_Light_MediaRouteButton = 2131361813;
+			// aapt resource value: 0x7f0b0155
+			public static int Widget_AppCompat_ProgressBar = 2131427669;
 			
-			// aapt resource value: 0x7f0a0016
-			public static int Widget_MediaRouter_MediaRouteButton = 2131361814;
+			// aapt resource value: 0x7f0b0156
+			public static int Widget_AppCompat_ProgressBar_Horizontal = 2131427670;
+			
+			// aapt resource value: 0x7f0b0157
+			public static int Widget_AppCompat_RatingBar = 2131427671;
+			
+			// aapt resource value: 0x7f0b0158
+			public static int Widget_AppCompat_RatingBar_Indicator = 2131427672;
+			
+			// aapt resource value: 0x7f0b0159
+			public static int Widget_AppCompat_RatingBar_Small = 2131427673;
+			
+			// aapt resource value: 0x7f0b015a
+			public static int Widget_AppCompat_SearchView = 2131427674;
+			
+			// aapt resource value: 0x7f0b015b
+			public static int Widget_AppCompat_SearchView_ActionBar = 2131427675;
+			
+			// aapt resource value: 0x7f0b015c
+			public static int Widget_AppCompat_SeekBar = 2131427676;
+			
+			// aapt resource value: 0x7f0b015d
+			public static int Widget_AppCompat_SeekBar_Discrete = 2131427677;
+			
+			// aapt resource value: 0x7f0b015e
+			public static int Widget_AppCompat_Spinner = 2131427678;
+			
+			// aapt resource value: 0x7f0b015f
+			public static int Widget_AppCompat_Spinner_DropDown = 2131427679;
+			
+			// aapt resource value: 0x7f0b0160
+			public static int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131427680;
+			
+			// aapt resource value: 0x7f0b0161
+			public static int Widget_AppCompat_Spinner_Underlined = 2131427681;
+			
+			// aapt resource value: 0x7f0b0162
+			public static int Widget_AppCompat_TextView_SpinnerItem = 2131427682;
+			
+			// aapt resource value: 0x7f0b0163
+			public static int Widget_AppCompat_Toolbar = 2131427683;
+			
+			// aapt resource value: 0x7f0b0164
+			public static int Widget_AppCompat_Toolbar_Button_Navigation = 2131427684;
+			
+			// aapt resource value: 0x7f0b018c
+			public static int Widget_Compat_NotificationActionContainer = 2131427724;
+			
+			// aapt resource value: 0x7f0b018d
+			public static int Widget_Compat_NotificationActionText = 2131427725;
+			
+			// aapt resource value: 0x7f0b017e
+			public static int Widget_Design_AppBarLayout = 2131427710;
+			
+			// aapt resource value: 0x7f0b017f
+			public static int Widget_Design_BottomNavigationView = 2131427711;
+			
+			// aapt resource value: 0x7f0b0180
+			public static int Widget_Design_BottomSheet_Modal = 2131427712;
+			
+			// aapt resource value: 0x7f0b0181
+			public static int Widget_Design_CollapsingToolbar = 2131427713;
+			
+			// aapt resource value: 0x7f0b0182
+			public static int Widget_Design_CoordinatorLayout = 2131427714;
+			
+			// aapt resource value: 0x7f0b0183
+			public static int Widget_Design_FloatingActionButton = 2131427715;
+			
+			// aapt resource value: 0x7f0b0184
+			public static int Widget_Design_NavigationView = 2131427716;
+			
+			// aapt resource value: 0x7f0b0185
+			public static int Widget_Design_ScrimInsetsFrameLayout = 2131427717;
+			
+			// aapt resource value: 0x7f0b0186
+			public static int Widget_Design_Snackbar = 2131427718;
+			
+			// aapt resource value: 0x7f0b016a
+			public static int Widget_Design_TabLayout = 2131427690;
+			
+			// aapt resource value: 0x7f0b0187
+			public static int Widget_Design_TextInputLayout = 2131427719;
+			
+			// aapt resource value: 0x7f0b0009
+			public static int Widget_MediaRouter_Light_MediaRouteButton = 2131427337;
+			
+			// aapt resource value: 0x7f0b000a
+			public static int Widget_MediaRouter_MediaRouteButton = 2131427338;
 			
 			static Style()
 			{
@@ -4174,7 +5321,11 @@ namespace SuaveControls.MaterialForms.Android
 		{
 			
 			public static int[] ActionBar = new int[] {
+					2130772003,
+					2130772005,
+					2130772006,
 					2130772007,
+					2130772008,
 					2130772009,
 					2130772010,
 					2130772011,
@@ -4198,9 +5349,7 @@ namespace SuaveControls.MaterialForms.Android
 					2130772029,
 					2130772030,
 					2130772031,
-					2130772032,
-					2130772033,
-					2130772090};
+					2130772101};
 			
 			// aapt resource value: 10
 			public static int ActionBar_background = 10;
@@ -4214,6 +5363,9 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 21
 			public static int ActionBar_contentInsetEnd = 21;
 			
+			// aapt resource value: 25
+			public static int ActionBar_contentInsetEndWithActions = 25;
+			
 			// aapt resource value: 22
 			public static int ActionBar_contentInsetLeft = 22;
 			
@@ -4222,6 +5374,9 @@ namespace SuaveControls.MaterialForms.Android
 			
 			// aapt resource value: 20
 			public static int ActionBar_contentInsetStart = 20;
+			
+			// aapt resource value: 24
+			public static int ActionBar_contentInsetStartWithNavigation = 24;
 			
 			// aapt resource value: 13
 			public static int ActionBar_customNavigationLayout = 13;
@@ -4232,8 +5387,8 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 9
 			public static int ActionBar_divider = 9;
 			
-			// aapt resource value: 24
-			public static int ActionBar_elevation = 24;
+			// aapt resource value: 26
+			public static int ActionBar_elevation = 26;
 			
 			// aapt resource value: 0
 			public static int ActionBar_height = 0;
@@ -4241,8 +5396,8 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 19
 			public static int ActionBar_hideOnContentScroll = 19;
 			
-			// aapt resource value: 26
-			public static int ActionBar_homeAsUpIndicator = 26;
+			// aapt resource value: 28
+			public static int ActionBar_homeAsUpIndicator = 28;
 			
 			// aapt resource value: 14
 			public static int ActionBar_homeLayout = 14;
@@ -4262,8 +5417,8 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 2
 			public static int ActionBar_navigationMode = 2;
 			
-			// aapt resource value: 25
-			public static int ActionBar_popupTheme = 25;
+			// aapt resource value: 27
+			public static int ActionBar_popupTheme = 27;
 			
 			// aapt resource value: 17
 			public static int ActionBar_progressBarPadding = 17;
@@ -4298,12 +5453,12 @@ namespace SuaveControls.MaterialForms.Android
 			public static int[] ActionMenuView;
 			
 			public static int[] ActionMode = new int[] {
-					2130772007,
-					2130772013,
+					2130772003,
+					2130772009,
+					2130772010,
 					2130772014,
-					2130772018,
-					2130772020,
-					2130772034};
+					2130772016,
+					2130772032};
 			
 			// aapt resource value: 3
 			public static int ActionMode_background = 3;
@@ -4324,8 +5479,8 @@ namespace SuaveControls.MaterialForms.Android
 			public static int ActionMode_titleTextStyle = 1;
 			
 			public static int[] ActivityChooserView = new int[] {
-					2130772035,
-					2130772036};
+					2130772033,
+					2130772034};
 			
 			// aapt resource value: 1
 			public static int ActivityChooserView_expandActivityOverflowButtonDrawable = 1;
@@ -4335,11 +5490,12 @@ namespace SuaveControls.MaterialForms.Android
 			
 			public static int[] AlertDialog = new int[] {
 					16842994,
+					2130772035,
+					2130772036,
 					2130772037,
 					2130772038,
 					2130772039,
-					2130772040,
-					2130772041};
+					2130772040};
 			
 			// aapt resource value: 0
 			public static int AlertDialog_android_layout = 0;
@@ -4356,36 +5512,59 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 3
 			public static int AlertDialog_multiChoiceItemLayout = 3;
 			
+			// aapt resource value: 6
+			public static int AlertDialog_showTitle = 6;
+			
 			// aapt resource value: 4
 			public static int AlertDialog_singleChoiceItemLayout = 4;
 			
 			public static int[] AppBarLayout = new int[] {
 					16842964,
-					2130772032,
-					2130772215};
+					16843919,
+					16844096,
+					2130772030,
+					2130772248};
 			
 			// aapt resource value: 0
 			public static int AppBarLayout_android_background = 0;
 			
-			// aapt resource value: 1
-			public static int AppBarLayout_elevation = 1;
-			
 			// aapt resource value: 2
-			public static int AppBarLayout_expanded = 2;
+			public static int AppBarLayout_android_keyboardNavigationCluster = 2;
 			
-			public static int[] AppBarLayout_LayoutParams = new int[] {
-					2130772216,
-					2130772217};
+			// aapt resource value: 1
+			public static int AppBarLayout_android_touchscreenBlocksFocus = 1;
+			
+			// aapt resource value: 3
+			public static int AppBarLayout_elevation = 3;
+			
+			// aapt resource value: 4
+			public static int AppBarLayout_expanded = 4;
+			
+			public static int[] AppBarLayoutStates = new int[] {
+					2130772249,
+					2130772250};
 			
 			// aapt resource value: 0
-			public static int AppBarLayout_LayoutParams_layout_scrollFlags = 0;
+			public static int AppBarLayoutStates_state_collapsed = 0;
 			
 			// aapt resource value: 1
-			public static int AppBarLayout_LayoutParams_layout_scrollInterpolator = 1;
+			public static int AppBarLayoutStates_state_collapsible = 1;
+			
+			public static int[] AppBarLayout_Layout = new int[] {
+					2130772251,
+					2130772252};
+			
+			// aapt resource value: 0
+			public static int AppBarLayout_Layout_layout_scrollFlags = 0;
+			
+			// aapt resource value: 1
+			public static int AppBarLayout_Layout_layout_scrollInterpolator = 1;
 			
 			public static int[] AppCompatImageView = new int[] {
 					16843033,
-					2130772042};
+					2130772041,
+					2130772042,
+					2130772043};
 			
 			// aapt resource value: 0
 			public static int AppCompatImageView_android_src = 0;
@@ -4393,12 +5572,90 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 1
 			public static int AppCompatImageView_srcCompat = 1;
 			
+			// aapt resource value: 2
+			public static int AppCompatImageView_tint = 2;
+			
+			// aapt resource value: 3
+			public static int AppCompatImageView_tintMode = 3;
+			
+			public static int[] AppCompatSeekBar = new int[] {
+					16843074,
+					2130772044,
+					2130772045,
+					2130772046};
+			
+			// aapt resource value: 0
+			public static int AppCompatSeekBar_android_thumb = 0;
+			
+			// aapt resource value: 1
+			public static int AppCompatSeekBar_tickMark = 1;
+			
+			// aapt resource value: 2
+			public static int AppCompatSeekBar_tickMarkTint = 2;
+			
+			// aapt resource value: 3
+			public static int AppCompatSeekBar_tickMarkTintMode = 3;
+			
+			public static int[] AppCompatTextHelper = new int[] {
+					16842804,
+					16843117,
+					16843118,
+					16843119,
+					16843120,
+					16843666,
+					16843667};
+			
+			// aapt resource value: 2
+			public static int AppCompatTextHelper_android_drawableBottom = 2;
+			
+			// aapt resource value: 6
+			public static int AppCompatTextHelper_android_drawableEnd = 6;
+			
+			// aapt resource value: 3
+			public static int AppCompatTextHelper_android_drawableLeft = 3;
+			
+			// aapt resource value: 4
+			public static int AppCompatTextHelper_android_drawableRight = 4;
+			
+			// aapt resource value: 5
+			public static int AppCompatTextHelper_android_drawableStart = 5;
+			
+			// aapt resource value: 1
+			public static int AppCompatTextHelper_android_drawableTop = 1;
+			
+			// aapt resource value: 0
+			public static int AppCompatTextHelper_android_textAppearance = 0;
+			
 			public static int[] AppCompatTextView = new int[] {
 					16842804,
-					2130772043};
+					2130772047,
+					2130772048,
+					2130772049,
+					2130772050,
+					2130772051,
+					2130772052,
+					2130772053};
 			
 			// aapt resource value: 0
 			public static int AppCompatTextView_android_textAppearance = 0;
+			
+			// aapt resource value: 6
+			public static int AppCompatTextView_autoSizeMaxTextSize = 6;
+			
+			// aapt resource value: 5
+			public static int AppCompatTextView_autoSizeMinTextSize = 5;
+			
+			// aapt resource value: 4
+			public static int AppCompatTextView_autoSizePresetSizes = 4;
+			
+			// aapt resource value: 3
+			public static int AppCompatTextView_autoSizeStepGranularity = 3;
+			
+			// aapt resource value: 2
+			public static int AppCompatTextView_autoSizeTextType = 2;
+			
+			// aapt resource value: 7
+			public static int AppCompatTextView_fontFamily = 7;
 			
 			// aapt resource value: 1
 			public static int AppCompatTextView_textAllCaps = 1;
@@ -4406,16 +5663,6 @@ namespace SuaveControls.MaterialForms.Android
 			public static int[] AppCompatTheme = new int[] {
 					16842839,
 					16842926,
-					2130772044,
-					2130772045,
-					2130772046,
-					2130772047,
-					2130772048,
-					2130772049,
-					2130772050,
-					2130772051,
-					2130772052,
-					2130772053,
 					2130772054,
 					2130772055,
 					2130772056,
@@ -4515,7 +5762,24 @@ namespace SuaveControls.MaterialForms.Android
 					2130772150,
 					2130772151,
 					2130772152,
-					2130772153};
+					2130772153,
+					2130772154,
+					2130772155,
+					2130772156,
+					2130772157,
+					2130772158,
+					2130772159,
+					2130772160,
+					2130772161,
+					2130772162,
+					2130772163,
+					2130772164,
+					2130772165,
+					2130772166,
+					2130772167,
+					2130772168,
+					2130772169,
+					2130772170};
 			
 			// aapt resource value: 23
 			public static int AppCompatTheme_actionBarDivider = 23;
@@ -4550,11 +5814,11 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 21
 			public static int AppCompatTheme_actionBarWidgetTheme = 21;
 			
-			// aapt resource value: 49
-			public static int AppCompatTheme_actionButtonStyle = 49;
+			// aapt resource value: 50
+			public static int AppCompatTheme_actionButtonStyle = 50;
 			
-			// aapt resource value: 45
-			public static int AppCompatTheme_actionDropDownStyle = 45;
+			// aapt resource value: 46
+			public static int AppCompatTheme_actionDropDownStyle = 46;
 			
 			// aapt resource value: 25
 			public static int AppCompatTheme_actionMenuTextAppearance = 25;
@@ -4607,20 +5871,20 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 16
 			public static int AppCompatTheme_actionOverflowMenuStyle = 16;
 			
-			// aapt resource value: 57
-			public static int AppCompatTheme_activityChooserViewStyle = 57;
+			// aapt resource value: 58
+			public static int AppCompatTheme_activityChooserViewStyle = 58;
 			
-			// aapt resource value: 92
-			public static int AppCompatTheme_alertDialogButtonGroupStyle = 92;
+			// aapt resource value: 95
+			public static int AppCompatTheme_alertDialogButtonGroupStyle = 95;
 			
-			// aapt resource value: 93
-			public static int AppCompatTheme_alertDialogCenterButtons = 93;
-			
-			// aapt resource value: 91
-			public static int AppCompatTheme_alertDialogStyle = 91;
+			// aapt resource value: 96
+			public static int AppCompatTheme_alertDialogCenterButtons = 96;
 			
 			// aapt resource value: 94
-			public static int AppCompatTheme_alertDialogTheme = 94;
+			public static int AppCompatTheme_alertDialogStyle = 94;
+			
+			// aapt resource value: 97
+			public static int AppCompatTheme_alertDialogTheme = 97;
 			
 			// aapt resource value: 1
 			public static int AppCompatTheme_android_windowAnimationStyle = 1;
@@ -4628,200 +5892,221 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 0
 			public static int AppCompatTheme_android_windowIsFloating = 0;
 			
-			// aapt resource value: 99
-			public static int AppCompatTheme_autoCompleteTextViewStyle = 99;
-			
-			// aapt resource value: 54
-			public static int AppCompatTheme_borderlessButtonStyle = 54;
-			
-			// aapt resource value: 51
-			public static int AppCompatTheme_buttonBarButtonStyle = 51;
-			
-			// aapt resource value: 97
-			public static int AppCompatTheme_buttonBarNegativeButtonStyle = 97;
-			
-			// aapt resource value: 98
-			public static int AppCompatTheme_buttonBarNeutralButtonStyle = 98;
-			
-			// aapt resource value: 96
-			public static int AppCompatTheme_buttonBarPositiveButtonStyle = 96;
-			
-			// aapt resource value: 50
-			public static int AppCompatTheme_buttonBarStyle = 50;
-			
-			// aapt resource value: 100
-			public static int AppCompatTheme_buttonStyle = 100;
-			
-			// aapt resource value: 101
-			public static int AppCompatTheme_buttonStyleSmall = 101;
-			
 			// aapt resource value: 102
-			public static int AppCompatTheme_checkboxStyle = 102;
-			
-			// aapt resource value: 103
-			public static int AppCompatTheme_checkedTextViewStyle = 103;
-			
-			// aapt resource value: 84
-			public static int AppCompatTheme_colorAccent = 84;
-			
-			// aapt resource value: 88
-			public static int AppCompatTheme_colorButtonNormal = 88;
-			
-			// aapt resource value: 86
-			public static int AppCompatTheme_colorControlActivated = 86;
-			
-			// aapt resource value: 87
-			public static int AppCompatTheme_colorControlHighlight = 87;
-			
-			// aapt resource value: 85
-			public static int AppCompatTheme_colorControlNormal = 85;
-			
-			// aapt resource value: 82
-			public static int AppCompatTheme_colorPrimary = 82;
-			
-			// aapt resource value: 83
-			public static int AppCompatTheme_colorPrimaryDark = 83;
-			
-			// aapt resource value: 89
-			public static int AppCompatTheme_colorSwitchThumbNormal = 89;
-			
-			// aapt resource value: 90
-			public static int AppCompatTheme_controlBackground = 90;
-			
-			// aapt resource value: 43
-			public static int AppCompatTheme_dialogPreferredPadding = 43;
-			
-			// aapt resource value: 42
-			public static int AppCompatTheme_dialogTheme = 42;
-			
-			// aapt resource value: 56
-			public static int AppCompatTheme_dividerHorizontal = 56;
+			public static int AppCompatTheme_autoCompleteTextViewStyle = 102;
 			
 			// aapt resource value: 55
-			public static int AppCompatTheme_dividerVertical = 55;
-			
-			// aapt resource value: 74
-			public static int AppCompatTheme_dropDownListViewStyle = 74;
-			
-			// aapt resource value: 46
-			public static int AppCompatTheme_dropdownListPreferredItemHeight = 46;
-			
-			// aapt resource value: 63
-			public static int AppCompatTheme_editTextBackground = 63;
-			
-			// aapt resource value: 62
-			public static int AppCompatTheme_editTextColor = 62;
-			
-			// aapt resource value: 104
-			public static int AppCompatTheme_editTextStyle = 104;
-			
-			// aapt resource value: 48
-			public static int AppCompatTheme_homeAsUpIndicator = 48;
-			
-			// aapt resource value: 64
-			public static int AppCompatTheme_imageButtonStyle = 64;
-			
-			// aapt resource value: 81
-			public static int AppCompatTheme_listChoiceBackgroundIndicator = 81;
-			
-			// aapt resource value: 44
-			public static int AppCompatTheme_listDividerAlertDialog = 44;
-			
-			// aapt resource value: 75
-			public static int AppCompatTheme_listPopupWindowStyle = 75;
-			
-			// aapt resource value: 69
-			public static int AppCompatTheme_listPreferredItemHeight = 69;
-			
-			// aapt resource value: 71
-			public static int AppCompatTheme_listPreferredItemHeightLarge = 71;
-			
-			// aapt resource value: 70
-			public static int AppCompatTheme_listPreferredItemHeightSmall = 70;
-			
-			// aapt resource value: 72
-			public static int AppCompatTheme_listPreferredItemPaddingLeft = 72;
-			
-			// aapt resource value: 73
-			public static int AppCompatTheme_listPreferredItemPaddingRight = 73;
-			
-			// aapt resource value: 78
-			public static int AppCompatTheme_panelBackground = 78;
-			
-			// aapt resource value: 80
-			public static int AppCompatTheme_panelMenuListTheme = 80;
-			
-			// aapt resource value: 79
-			public static int AppCompatTheme_panelMenuListWidth = 79;
-			
-			// aapt resource value: 60
-			public static int AppCompatTheme_popupMenuStyle = 60;
-			
-			// aapt resource value: 61
-			public static int AppCompatTheme_popupWindowStyle = 61;
-			
-			// aapt resource value: 105
-			public static int AppCompatTheme_radioButtonStyle = 105;
-			
-			// aapt resource value: 106
-			public static int AppCompatTheme_ratingBarStyle = 106;
-			
-			// aapt resource value: 107
-			public static int AppCompatTheme_ratingBarStyleIndicator = 107;
-			
-			// aapt resource value: 108
-			public static int AppCompatTheme_ratingBarStyleSmall = 108;
-			
-			// aapt resource value: 68
-			public static int AppCompatTheme_searchViewStyle = 68;
-			
-			// aapt resource value: 109
-			public static int AppCompatTheme_seekBarStyle = 109;
+			public static int AppCompatTheme_borderlessButtonStyle = 55;
 			
 			// aapt resource value: 52
-			public static int AppCompatTheme_selectableItemBackground = 52;
+			public static int AppCompatTheme_buttonBarButtonStyle = 52;
 			
-			// aapt resource value: 53
-			public static int AppCompatTheme_selectableItemBackgroundBorderless = 53;
+			// aapt resource value: 100
+			public static int AppCompatTheme_buttonBarNegativeButtonStyle = 100;
+			
+			// aapt resource value: 101
+			public static int AppCompatTheme_buttonBarNeutralButtonStyle = 101;
+			
+			// aapt resource value: 99
+			public static int AppCompatTheme_buttonBarPositiveButtonStyle = 99;
+			
+			// aapt resource value: 51
+			public static int AppCompatTheme_buttonBarStyle = 51;
+			
+			// aapt resource value: 103
+			public static int AppCompatTheme_buttonStyle = 103;
+			
+			// aapt resource value: 104
+			public static int AppCompatTheme_buttonStyleSmall = 104;
+			
+			// aapt resource value: 105
+			public static int AppCompatTheme_checkboxStyle = 105;
+			
+			// aapt resource value: 106
+			public static int AppCompatTheme_checkedTextViewStyle = 106;
+			
+			// aapt resource value: 86
+			public static int AppCompatTheme_colorAccent = 86;
+			
+			// aapt resource value: 93
+			public static int AppCompatTheme_colorBackgroundFloating = 93;
+			
+			// aapt resource value: 90
+			public static int AppCompatTheme_colorButtonNormal = 90;
+			
+			// aapt resource value: 88
+			public static int AppCompatTheme_colorControlActivated = 88;
+			
+			// aapt resource value: 89
+			public static int AppCompatTheme_colorControlHighlight = 89;
+			
+			// aapt resource value: 87
+			public static int AppCompatTheme_colorControlNormal = 87;
+			
+			// aapt resource value: 118
+			public static int AppCompatTheme_colorError = 118;
+			
+			// aapt resource value: 84
+			public static int AppCompatTheme_colorPrimary = 84;
+			
+			// aapt resource value: 85
+			public static int AppCompatTheme_colorPrimaryDark = 85;
+			
+			// aapt resource value: 91
+			public static int AppCompatTheme_colorSwitchThumbNormal = 91;
+			
+			// aapt resource value: 92
+			public static int AppCompatTheme_controlBackground = 92;
+			
+			// aapt resource value: 44
+			public static int AppCompatTheme_dialogPreferredPadding = 44;
+			
+			// aapt resource value: 43
+			public static int AppCompatTheme_dialogTheme = 43;
+			
+			// aapt resource value: 57
+			public static int AppCompatTheme_dividerHorizontal = 57;
+			
+			// aapt resource value: 56
+			public static int AppCompatTheme_dividerVertical = 56;
+			
+			// aapt resource value: 75
+			public static int AppCompatTheme_dropDownListViewStyle = 75;
 			
 			// aapt resource value: 47
-			public static int AppCompatTheme_spinnerDropDownItemStyle = 47;
+			public static int AppCompatTheme_dropdownListPreferredItemHeight = 47;
+			
+			// aapt resource value: 64
+			public static int AppCompatTheme_editTextBackground = 64;
+			
+			// aapt resource value: 63
+			public static int AppCompatTheme_editTextColor = 63;
+			
+			// aapt resource value: 107
+			public static int AppCompatTheme_editTextStyle = 107;
+			
+			// aapt resource value: 49
+			public static int AppCompatTheme_homeAsUpIndicator = 49;
+			
+			// aapt resource value: 65
+			public static int AppCompatTheme_imageButtonStyle = 65;
+			
+			// aapt resource value: 83
+			public static int AppCompatTheme_listChoiceBackgroundIndicator = 83;
+			
+			// aapt resource value: 45
+			public static int AppCompatTheme_listDividerAlertDialog = 45;
+			
+			// aapt resource value: 115
+			public static int AppCompatTheme_listMenuViewStyle = 115;
+			
+			// aapt resource value: 76
+			public static int AppCompatTheme_listPopupWindowStyle = 76;
+			
+			// aapt resource value: 70
+			public static int AppCompatTheme_listPreferredItemHeight = 70;
+			
+			// aapt resource value: 72
+			public static int AppCompatTheme_listPreferredItemHeightLarge = 72;
+			
+			// aapt resource value: 71
+			public static int AppCompatTheme_listPreferredItemHeightSmall = 71;
+			
+			// aapt resource value: 73
+			public static int AppCompatTheme_listPreferredItemPaddingLeft = 73;
+			
+			// aapt resource value: 74
+			public static int AppCompatTheme_listPreferredItemPaddingRight = 74;
+			
+			// aapt resource value: 80
+			public static int AppCompatTheme_panelBackground = 80;
+			
+			// aapt resource value: 82
+			public static int AppCompatTheme_panelMenuListTheme = 82;
+			
+			// aapt resource value: 81
+			public static int AppCompatTheme_panelMenuListWidth = 81;
+			
+			// aapt resource value: 61
+			public static int AppCompatTheme_popupMenuStyle = 61;
+			
+			// aapt resource value: 62
+			public static int AppCompatTheme_popupWindowStyle = 62;
+			
+			// aapt resource value: 108
+			public static int AppCompatTheme_radioButtonStyle = 108;
+			
+			// aapt resource value: 109
+			public static int AppCompatTheme_ratingBarStyle = 109;
 			
 			// aapt resource value: 110
-			public static int AppCompatTheme_spinnerStyle = 110;
+			public static int AppCompatTheme_ratingBarStyleIndicator = 110;
 			
 			// aapt resource value: 111
-			public static int AppCompatTheme_switchStyle = 111;
+			public static int AppCompatTheme_ratingBarStyleSmall = 111;
+			
+			// aapt resource value: 69
+			public static int AppCompatTheme_searchViewStyle = 69;
+			
+			// aapt resource value: 112
+			public static int AppCompatTheme_seekBarStyle = 112;
+			
+			// aapt resource value: 53
+			public static int AppCompatTheme_selectableItemBackground = 53;
+			
+			// aapt resource value: 54
+			public static int AppCompatTheme_selectableItemBackgroundBorderless = 54;
+			
+			// aapt resource value: 48
+			public static int AppCompatTheme_spinnerDropDownItemStyle = 48;
+			
+			// aapt resource value: 113
+			public static int AppCompatTheme_spinnerStyle = 113;
+			
+			// aapt resource value: 114
+			public static int AppCompatTheme_switchStyle = 114;
 			
 			// aapt resource value: 40
 			public static int AppCompatTheme_textAppearanceLargePopupMenu = 40;
 			
-			// aapt resource value: 76
-			public static int AppCompatTheme_textAppearanceListItem = 76;
-			
 			// aapt resource value: 77
-			public static int AppCompatTheme_textAppearanceListItemSmall = 77;
+			public static int AppCompatTheme_textAppearanceListItem = 77;
+			
+			// aapt resource value: 78
+			public static int AppCompatTheme_textAppearanceListItemSecondary = 78;
+			
+			// aapt resource value: 79
+			public static int AppCompatTheme_textAppearanceListItemSmall = 79;
+			
+			// aapt resource value: 42
+			public static int AppCompatTheme_textAppearancePopupMenuHeader = 42;
+			
+			// aapt resource value: 67
+			public static int AppCompatTheme_textAppearanceSearchResultSubtitle = 67;
 			
 			// aapt resource value: 66
-			public static int AppCompatTheme_textAppearanceSearchResultSubtitle = 66;
-			
-			// aapt resource value: 65
-			public static int AppCompatTheme_textAppearanceSearchResultTitle = 65;
+			public static int AppCompatTheme_textAppearanceSearchResultTitle = 66;
 			
 			// aapt resource value: 41
 			public static int AppCompatTheme_textAppearanceSmallPopupMenu = 41;
 			
-			// aapt resource value: 95
-			public static int AppCompatTheme_textColorAlertDialogListItem = 95;
+			// aapt resource value: 98
+			public static int AppCompatTheme_textColorAlertDialogListItem = 98;
 			
-			// aapt resource value: 67
-			public static int AppCompatTheme_textColorSearchUrl = 67;
+			// aapt resource value: 68
+			public static int AppCompatTheme_textColorSearchUrl = 68;
+			
+			// aapt resource value: 60
+			public static int AppCompatTheme_toolbarNavigationButtonStyle = 60;
 			
 			// aapt resource value: 59
-			public static int AppCompatTheme_toolbarNavigationButtonStyle = 59;
+			public static int AppCompatTheme_toolbarStyle = 59;
 			
-			// aapt resource value: 58
-			public static int AppCompatTheme_toolbarStyle = 58;
+			// aapt resource value: 117
+			public static int AppCompatTheme_tooltipForegroundColor = 117;
+			
+			// aapt resource value: 116
+			public static int AppCompatTheme_tooltipFrameBackground = 116;
 			
 			// aapt resource value: 2
 			public static int AppCompatTheme_windowActionBar = 2;
@@ -4853,18 +6138,44 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 3
 			public static int AppCompatTheme_windowNoTitle = 3;
 			
-			public static int[] BottomSheetBehavior_Params = new int[] {
-					2130772218,
-					2130772219};
-			
-			// aapt resource value: 1
-			public static int BottomSheetBehavior_Params_behavior_hideable = 1;
+			public static int[] BottomNavigationView = new int[] {
+					2130772030,
+					2130772291,
+					2130772292,
+					2130772293,
+					2130772294};
 			
 			// aapt resource value: 0
-			public static int BottomSheetBehavior_Params_behavior_peekHeight = 0;
+			public static int BottomNavigationView_elevation = 0;
+			
+			// aapt resource value: 4
+			public static int BottomNavigationView_itemBackground = 4;
+			
+			// aapt resource value: 2
+			public static int BottomNavigationView_itemIconTint = 2;
+			
+			// aapt resource value: 3
+			public static int BottomNavigationView_itemTextColor = 3;
+			
+			// aapt resource value: 1
+			public static int BottomNavigationView_menu = 1;
+			
+			public static int[] BottomSheetBehavior_Layout = new int[] {
+					2130772253,
+					2130772254,
+					2130772255};
+			
+			// aapt resource value: 1
+			public static int BottomSheetBehavior_Layout_behavior_hideable = 1;
+			
+			// aapt resource value: 0
+			public static int BottomSheetBehavior_Layout_behavior_peekHeight = 0;
+			
+			// aapt resource value: 2
+			public static int BottomSheetBehavior_Layout_behavior_skipCollapsed = 2;
 			
 			public static int[] ButtonBarLayout = new int[] {
-					2130772154};
+					2130772171};
 			
 			// aapt resource value: 0
 			public static int ButtonBarLayout_allowStacking = 0;
@@ -4872,17 +6183,17 @@ namespace SuaveControls.MaterialForms.Android
 			public static int[] CardView = new int[] {
 					16843071,
 					16843072,
+					2130771991,
+					2130771992,
+					2130771993,
+					2130771994,
 					2130771995,
 					2130771996,
 					2130771997,
 					2130771998,
 					2130771999,
 					2130772000,
-					2130772001,
-					2130772002,
-					2130772003,
-					2130772004,
-					2130772005};
+					2130772001};
 			
 			// aapt resource value: 1
 			public static int CardView_android_minHeight = 1;
@@ -4923,34 +6234,26 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 11
 			public static int CardView_contentPaddingTop = 11;
 			
-			public static int[] CollapsingAppBarLayout_LayoutParams = new int[] {
-					2130772220,
-					2130772221};
-			
-			// aapt resource value: 0
-			public static int CollapsingAppBarLayout_LayoutParams_layout_collapseMode = 0;
-			
-			// aapt resource value: 1
-			public static int CollapsingAppBarLayout_LayoutParams_layout_collapseParallaxMultiplier = 1;
-			
 			public static int[] CollapsingToolbarLayout = new int[] {
-					2130772009,
-					2130772222,
-					2130772223,
-					2130772224,
-					2130772225,
-					2130772226,
-					2130772227,
-					2130772228,
-					2130772229,
-					2130772230,
-					2130772231,
-					2130772232,
-					2130772233,
-					2130772234};
+					2130772005,
+					2130772256,
+					2130772257,
+					2130772258,
+					2130772259,
+					2130772260,
+					2130772261,
+					2130772262,
+					2130772263,
+					2130772264,
+					2130772265,
+					2130772266,
+					2130772267,
+					2130772268,
+					2130772269,
+					2130772270};
 			
-			// aapt resource value: 11
-			public static int CollapsingToolbarLayout_collapsedTitleGravity = 11;
+			// aapt resource value: 13
+			public static int CollapsingToolbarLayout_collapsedTitleGravity = 13;
 			
 			// aapt resource value: 7
 			public static int CollapsingToolbarLayout_collapsedTitleTextAppearance = 7;
@@ -4958,8 +6261,8 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 8
 			public static int CollapsingToolbarLayout_contentScrim = 8;
 			
-			// aapt resource value: 12
-			public static int CollapsingToolbarLayout_expandedTitleGravity = 12;
+			// aapt resource value: 14
+			public static int CollapsingToolbarLayout_expandedTitleGravity = 14;
 			
 			// aapt resource value: 1
 			public static int CollapsingToolbarLayout_expandedTitleMargin = 1;
@@ -4979,22 +6282,52 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 6
 			public static int CollapsingToolbarLayout_expandedTitleTextAppearance = 6;
 			
+			// aapt resource value: 12
+			public static int CollapsingToolbarLayout_scrimAnimationDuration = 12;
+			
+			// aapt resource value: 11
+			public static int CollapsingToolbarLayout_scrimVisibleHeightTrigger = 11;
+			
 			// aapt resource value: 9
 			public static int CollapsingToolbarLayout_statusBarScrim = 9;
 			
 			// aapt resource value: 0
 			public static int CollapsingToolbarLayout_title = 0;
 			
-			// aapt resource value: 13
-			public static int CollapsingToolbarLayout_titleEnabled = 13;
+			// aapt resource value: 15
+			public static int CollapsingToolbarLayout_titleEnabled = 15;
 			
 			// aapt resource value: 10
 			public static int CollapsingToolbarLayout_toolbarId = 10;
 			
+			public static int[] CollapsingToolbarLayout_Layout = new int[] {
+					2130772271,
+					2130772272};
+			
+			// aapt resource value: 0
+			public static int CollapsingToolbarLayout_Layout_layout_collapseMode = 0;
+			
+			// aapt resource value: 1
+			public static int CollapsingToolbarLayout_Layout_layout_collapseParallaxMultiplier = 1;
+			
+			public static int[] ColorStateListItem = new int[] {
+					16843173,
+					16843551,
+					2130772172};
+			
+			// aapt resource value: 2
+			public static int ColorStateListItem_alpha = 2;
+			
+			// aapt resource value: 1
+			public static int ColorStateListItem_android_alpha = 1;
+			
+			// aapt resource value: 0
+			public static int ColorStateListItem_android_color = 0;
+			
 			public static int[] CompoundButton = new int[] {
 					16843015,
-					2130772155,
-					2130772156};
+					2130772173,
+					2130772174};
 			
 			// aapt resource value: 0
 			public static int CompoundButton_android_button = 0;
@@ -5006,8 +6339,8 @@ namespace SuaveControls.MaterialForms.Android
 			public static int CompoundButton_buttonTintMode = 2;
 			
 			public static int[] CoordinatorLayout = new int[] {
-					2130772235,
-					2130772236};
+					2130772273,
+					2130772274};
 			
 			// aapt resource value: 0
 			public static int CoordinatorLayout_keylines = 0;
@@ -5015,32 +6348,40 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 1
 			public static int CoordinatorLayout_statusBarBackground = 1;
 			
-			public static int[] CoordinatorLayout_LayoutParams = new int[] {
+			public static int[] CoordinatorLayout_Layout = new int[] {
 					16842931,
-					2130772237,
-					2130772238,
-					2130772239,
-					2130772240};
+					2130772275,
+					2130772276,
+					2130772277,
+					2130772278,
+					2130772279,
+					2130772280};
 			
 			// aapt resource value: 0
-			public static int CoordinatorLayout_LayoutParams_android_layout_gravity = 0;
+			public static int CoordinatorLayout_Layout_android_layout_gravity = 0;
 			
 			// aapt resource value: 2
-			public static int CoordinatorLayout_LayoutParams_layout_anchor = 2;
+			public static int CoordinatorLayout_Layout_layout_anchor = 2;
 			
 			// aapt resource value: 4
-			public static int CoordinatorLayout_LayoutParams_layout_anchorGravity = 4;
+			public static int CoordinatorLayout_Layout_layout_anchorGravity = 4;
 			
 			// aapt resource value: 1
-			public static int CoordinatorLayout_LayoutParams_layout_behavior = 1;
+			public static int CoordinatorLayout_Layout_layout_behavior = 1;
+			
+			// aapt resource value: 6
+			public static int CoordinatorLayout_Layout_layout_dodgeInsetEdges = 6;
+			
+			// aapt resource value: 5
+			public static int CoordinatorLayout_Layout_layout_insetEdge = 5;
 			
 			// aapt resource value: 3
-			public static int CoordinatorLayout_LayoutParams_layout_keyline = 3;
+			public static int CoordinatorLayout_Layout_layout_keyline = 3;
 			
 			public static int[] DesignTheme = new int[] {
-					2130772241,
-					2130772242,
-					2130772243};
+					2130772281,
+					2130772282,
+					2130772283};
 			
 			// aapt resource value: 0
 			public static int DesignTheme_bottomSheetDialogTheme = 0;
@@ -5052,14 +6393,14 @@ namespace SuaveControls.MaterialForms.Android
 			public static int DesignTheme_textColorError = 2;
 			
 			public static int[] DrawerArrowToggle = new int[] {
-					2130772157,
-					2130772158,
-					2130772159,
-					2130772160,
-					2130772161,
-					2130772162,
-					2130772163,
-					2130772164};
+					2130772175,
+					2130772176,
+					2130772177,
+					2130772178,
+					2130772179,
+					2130772180,
+					2130772181,
+					2130772182};
 			
 			// aapt resource value: 4
 			public static int DrawerArrowToggle_arrowHeadLength = 4;
@@ -5086,14 +6427,14 @@ namespace SuaveControls.MaterialForms.Android
 			public static int DrawerArrowToggle_thickness = 7;
 			
 			public static int[] FloatingActionButton = new int[] {
-					2130772032,
-					2130772213,
-					2130772214,
-					2130772244,
-					2130772245,
+					2130772030,
 					2130772246,
 					2130772247,
-					2130772248};
+					2130772284,
+					2130772285,
+					2130772286,
+					2130772287,
+					2130772288};
 			
 			// aapt resource value: 1
 			public static int FloatingActionButton_backgroundTint = 1;
@@ -5119,10 +6460,68 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 7
 			public static int FloatingActionButton_useCompatPadding = 7;
 			
+			public static int[] FloatingActionButton_Behavior_Layout = new int[] {
+					2130772289};
+			
+			// aapt resource value: 0
+			public static int FloatingActionButton_Behavior_Layout_behavior_autoHide = 0;
+			
+			public static int[] FontFamily = new int[] {
+					2130772330,
+					2130772331,
+					2130772332,
+					2130772333,
+					2130772334,
+					2130772335};
+			
+			// aapt resource value: 0
+			public static int FontFamily_fontProviderAuthority = 0;
+			
+			// aapt resource value: 3
+			public static int FontFamily_fontProviderCerts = 3;
+			
+			// aapt resource value: 4
+			public static int FontFamily_fontProviderFetchStrategy = 4;
+			
+			// aapt resource value: 5
+			public static int FontFamily_fontProviderFetchTimeout = 5;
+			
+			// aapt resource value: 1
+			public static int FontFamily_fontProviderPackage = 1;
+			
+			// aapt resource value: 2
+			public static int FontFamily_fontProviderQuery = 2;
+			
+			public static int[] FontFamilyFont = new int[] {
+					16844082,
+					16844083,
+					16844095,
+					2130772336,
+					2130772337,
+					2130772338};
+			
+			// aapt resource value: 0
+			public static int FontFamilyFont_android_font = 0;
+			
+			// aapt resource value: 2
+			public static int FontFamilyFont_android_fontStyle = 2;
+			
+			// aapt resource value: 1
+			public static int FontFamilyFont_android_fontWeight = 1;
+			
+			// aapt resource value: 4
+			public static int FontFamilyFont_font = 4;
+			
+			// aapt resource value: 3
+			public static int FontFamilyFont_fontStyle = 3;
+			
+			// aapt resource value: 5
+			public static int FontFamilyFont_fontWeight = 5;
+			
 			public static int[] ForegroundLinearLayout = new int[] {
 					16843017,
 					16843264,
-					2130772249};
+					2130772290};
 			
 			// aapt resource value: 0
 			public static int ForegroundLinearLayout_android_foreground = 0;
@@ -5139,10 +6538,10 @@ namespace SuaveControls.MaterialForms.Android
 					16843046,
 					16843047,
 					16843048,
-					2130772017,
-					2130772165,
-					2130772166,
-					2130772167};
+					2130772013,
+					2130772183,
+					2130772184,
+					2130772185};
 			
 			// aapt resource value: 2
 			public static int LinearLayoutCompat_android_baselineAligned = 2;
@@ -5202,7 +6601,8 @@ namespace SuaveControls.MaterialForms.Android
 			public static int[] MediaRouteButton = new int[] {
 					16843071,
 					16843072,
-					2130771994};
+					2130771989,
+					2130771990};
 			
 			// aapt resource value: 1
 			public static int MediaRouteButton_android_minHeight = 1;
@@ -5212,6 +6612,9 @@ namespace SuaveControls.MaterialForms.Android
 			
 			// aapt resource value: 2
 			public static int MediaRouteButton_externalRouteEnabledDrawable = 2;
+			
+			// aapt resource value: 3
+			public static int MediaRouteButton_mediaRouteButtonTint = 3;
 			
 			public static int[] MenuGroup = new int[] {
 					16842766,
@@ -5253,19 +6656,28 @@ namespace SuaveControls.MaterialForms.Android
 					16843236,
 					16843237,
 					16843375,
-					2130772168,
-					2130772169,
-					2130772170,
-					2130772171};
-			
-			// aapt resource value: 14
-			public static int MenuItem_actionLayout = 14;
+					2130772186,
+					2130772187,
+					2130772188,
+					2130772189,
+					2130772190,
+					2130772191,
+					2130772192,
+					2130772193,
+					2130772194,
+					2130772195};
 			
 			// aapt resource value: 16
-			public static int MenuItem_actionProviderClass = 16;
+			public static int MenuItem_actionLayout = 16;
 			
-			// aapt resource value: 15
-			public static int MenuItem_actionViewClass = 15;
+			// aapt resource value: 18
+			public static int MenuItem_actionProviderClass = 18;
+			
+			// aapt resource value: 17
+			public static int MenuItem_actionViewClass = 17;
+			
+			// aapt resource value: 13
+			public static int MenuItem_alphabeticModifiers = 13;
 			
 			// aapt resource value: 9
 			public static int MenuItem_android_alphabeticShortcut = 9;
@@ -5306,8 +6718,23 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 4
 			public static int MenuItem_android_visible = 4;
 			
-			// aapt resource value: 13
-			public static int MenuItem_showAsAction = 13;
+			// aapt resource value: 19
+			public static int MenuItem_contentDescription = 19;
+			
+			// aapt resource value: 21
+			public static int MenuItem_iconTint = 21;
+			
+			// aapt resource value: 22
+			public static int MenuItem_iconTintMode = 22;
+			
+			// aapt resource value: 14
+			public static int MenuItem_numericModifiers = 14;
+			
+			// aapt resource value: 15
+			public static int MenuItem_showAsAction = 15;
+			
+			// aapt resource value: 20
+			public static int MenuItem_tooltipText = 20;
 			
 			public static int[] MenuView = new int[] {
 					16842926,
@@ -5317,7 +6744,8 @@ namespace SuaveControls.MaterialForms.Android
 					16843055,
 					16843056,
 					16843057,
-					2130772172};
+					2130772196,
+					2130772197};
 			
 			// aapt resource value: 4
 			public static int MenuView_android_headerBackground = 4;
@@ -5343,17 +6771,20 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 7
 			public static int MenuView_preserveIconSpacing = 7;
 			
+			// aapt resource value: 8
+			public static int MenuView_subMenuArrow = 8;
+			
 			public static int[] NavigationView = new int[] {
 					16842964,
 					16842973,
 					16843039,
-					2130772032,
-					2130772250,
-					2130772251,
-					2130772252,
-					2130772253,
-					2130772254,
-					2130772255};
+					2130772030,
+					2130772291,
+					2130772292,
+					2130772293,
+					2130772294,
+					2130772295,
+					2130772296};
 			
 			// aapt resource value: 0
 			public static int NavigationView_android_background = 0;
@@ -5387,72 +6818,110 @@ namespace SuaveControls.MaterialForms.Android
 			
 			public static int[] PopupWindow = new int[] {
 					16843126,
-					2130772173};
+					16843465,
+					2130772198};
+			
+			// aapt resource value: 1
+			public static int PopupWindow_android_popupAnimationStyle = 1;
 			
 			// aapt resource value: 0
 			public static int PopupWindow_android_popupBackground = 0;
 			
-			// aapt resource value: 1
-			public static int PopupWindow_overlapAnchor = 1;
+			// aapt resource value: 2
+			public static int PopupWindow_overlapAnchor = 2;
 			
 			public static int[] PopupWindowBackgroundState = new int[] {
-					2130772174};
+					2130772199};
 			
 			// aapt resource value: 0
 			public static int PopupWindowBackgroundState_state_above_anchor = 0;
 			
+			public static int[] RecycleListView = new int[] {
+					2130772200,
+					2130772201};
+			
+			// aapt resource value: 0
+			public static int RecycleListView_paddingBottomNoButtons = 0;
+			
+			// aapt resource value: 1
+			public static int RecycleListView_paddingTopNoTitle = 1;
+			
 			public static int[] RecyclerView = new int[] {
 					16842948,
+					16842993,
 					2130771968,
 					2130771969,
 					2130771970,
-					2130771971};
+					2130771971,
+					2130771972,
+					2130771973,
+					2130771974,
+					2130771975,
+					2130771976};
+			
+			// aapt resource value: 1
+			public static int RecyclerView_android_descendantFocusability = 1;
 			
 			// aapt resource value: 0
 			public static int RecyclerView_android_orientation = 0;
 			
-			// aapt resource value: 1
-			public static int RecyclerView_layoutManager = 1;
+			// aapt resource value: 6
+			public static int RecyclerView_fastScrollEnabled = 6;
 			
-			// aapt resource value: 3
-			public static int RecyclerView_reverseLayout = 3;
+			// aapt resource value: 9
+			public static int RecyclerView_fastScrollHorizontalThumbDrawable = 9;
+			
+			// aapt resource value: 10
+			public static int RecyclerView_fastScrollHorizontalTrackDrawable = 10;
+			
+			// aapt resource value: 7
+			public static int RecyclerView_fastScrollVerticalThumbDrawable = 7;
+			
+			// aapt resource value: 8
+			public static int RecyclerView_fastScrollVerticalTrackDrawable = 8;
 			
 			// aapt resource value: 2
-			public static int RecyclerView_spanCount = 2;
+			public static int RecyclerView_layoutManager = 2;
 			
 			// aapt resource value: 4
-			public static int RecyclerView_stackFromEnd = 4;
+			public static int RecyclerView_reverseLayout = 4;
+			
+			// aapt resource value: 3
+			public static int RecyclerView_spanCount = 3;
+			
+			// aapt resource value: 5
+			public static int RecyclerView_stackFromEnd = 5;
 			
 			public static int[] ScrimInsetsFrameLayout = new int[] {
-					2130772256};
+					2130772297};
 			
 			// aapt resource value: 0
 			public static int ScrimInsetsFrameLayout_insetForeground = 0;
 			
-			public static int[] ScrollingViewBehavior_Params = new int[] {
-					2130772257};
+			public static int[] ScrollingViewBehavior_Layout = new int[] {
+					2130772298};
 			
 			// aapt resource value: 0
-			public static int ScrollingViewBehavior_Params_behavior_overlapTop = 0;
+			public static int ScrollingViewBehavior_Layout_behavior_overlapTop = 0;
 			
 			public static int[] SearchView = new int[] {
 					16842970,
 					16843039,
 					16843296,
 					16843364,
-					2130772175,
-					2130772176,
-					2130772177,
-					2130772178,
-					2130772179,
-					2130772180,
-					2130772181,
-					2130772182,
-					2130772183,
-					2130772184,
-					2130772185,
-					2130772186,
-					2130772187};
+					2130772202,
+					2130772203,
+					2130772204,
+					2130772205,
+					2130772206,
+					2130772207,
+					2130772208,
+					2130772209,
+					2130772210,
+					2130772211,
+					2130772212,
+					2130772213,
+					2130772214};
 			
 			// aapt resource value: 0
 			public static int SearchView_android_focusable = 0;
@@ -5507,8 +6976,8 @@ namespace SuaveControls.MaterialForms.Android
 			
 			public static int[] SnackbarLayout = new int[] {
 					16843039,
-					2130772032,
-					2130772258};
+					2130772030,
+					2130772299};
 			
 			// aapt resource value: 0
 			public static int SnackbarLayout_android_maxWidth = 0;
@@ -5524,7 +6993,7 @@ namespace SuaveControls.MaterialForms.Android
 					16843126,
 					16843131,
 					16843362,
-					2130772033};
+					2130772031};
 			
 			// aapt resource value: 3
 			public static int Spinner_android_dropDownWidth = 3;
@@ -5545,13 +7014,17 @@ namespace SuaveControls.MaterialForms.Android
 					16843044,
 					16843045,
 					16843074,
-					2130772188,
-					2130772189,
-					2130772190,
-					2130772191,
-					2130772192,
-					2130772193,
-					2130772194};
+					2130772215,
+					2130772216,
+					2130772217,
+					2130772218,
+					2130772219,
+					2130772220,
+					2130772221,
+					2130772222,
+					2130772223,
+					2130772224,
+					2130772225};
 			
 			// aapt resource value: 1
 			public static int SwitchCompat_android_textOff = 1;
@@ -5562,26 +7035,38 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 2
 			public static int SwitchCompat_android_thumb = 2;
 			
+			// aapt resource value: 13
+			public static int SwitchCompat_showText = 13;
+			
+			// aapt resource value: 12
+			public static int SwitchCompat_splitTrack = 12;
+			
+			// aapt resource value: 10
+			public static int SwitchCompat_switchMinWidth = 10;
+			
+			// aapt resource value: 11
+			public static int SwitchCompat_switchPadding = 11;
+			
 			// aapt resource value: 9
-			public static int SwitchCompat_showText = 9;
+			public static int SwitchCompat_switchTextAppearance = 9;
 			
 			// aapt resource value: 8
-			public static int SwitchCompat_splitTrack = 8;
-			
-			// aapt resource value: 6
-			public static int SwitchCompat_switchMinWidth = 6;
-			
-			// aapt resource value: 7
-			public static int SwitchCompat_switchPadding = 7;
-			
-			// aapt resource value: 5
-			public static int SwitchCompat_switchTextAppearance = 5;
-			
-			// aapt resource value: 4
-			public static int SwitchCompat_thumbTextPadding = 4;
+			public static int SwitchCompat_thumbTextPadding = 8;
 			
 			// aapt resource value: 3
-			public static int SwitchCompat_track = 3;
+			public static int SwitchCompat_thumbTint = 3;
+			
+			// aapt resource value: 4
+			public static int SwitchCompat_thumbTintMode = 4;
+			
+			// aapt resource value: 5
+			public static int SwitchCompat_track = 5;
+			
+			// aapt resource value: 6
+			public static int SwitchCompat_trackTint = 6;
+			
+			// aapt resource value: 7
+			public static int SwitchCompat_trackTintMode = 7;
 			
 			public static int[] TabItem = new int[] {
 					16842754,
@@ -5598,22 +7083,22 @@ namespace SuaveControls.MaterialForms.Android
 			public static int TabItem_android_text = 2;
 			
 			public static int[] TabLayout = new int[] {
-					2130772259,
-					2130772260,
-					2130772261,
-					2130772262,
-					2130772263,
-					2130772264,
-					2130772265,
-					2130772266,
-					2130772267,
-					2130772268,
-					2130772269,
-					2130772270,
-					2130772271,
-					2130772272,
-					2130772273,
-					2130772274};
+					2130772300,
+					2130772301,
+					2130772302,
+					2130772303,
+					2130772304,
+					2130772305,
+					2130772306,
+					2130772307,
+					2130772308,
+					2130772309,
+					2130772310,
+					2130772311,
+					2130772312,
+					2130772313,
+					2130772314,
+					2130772315};
 			
 			// aapt resource value: 3
 			public static int TabLayout_tabBackground = 3;
@@ -5668,26 +7153,39 @@ namespace SuaveControls.MaterialForms.Android
 					16842902,
 					16842903,
 					16842904,
+					16842906,
+					16842907,
 					16843105,
 					16843106,
 					16843107,
 					16843108,
-					2130772043};
+					16843692,
+					2130772047,
+					2130772053};
 			
-			// aapt resource value: 4
-			public static int TextAppearance_android_shadowColor = 4;
-			
-			// aapt resource value: 5
-			public static int TextAppearance_android_shadowDx = 5;
+			// aapt resource value: 10
+			public static int TextAppearance_android_fontFamily = 10;
 			
 			// aapt resource value: 6
-			public static int TextAppearance_android_shadowDy = 6;
+			public static int TextAppearance_android_shadowColor = 6;
 			
 			// aapt resource value: 7
-			public static int TextAppearance_android_shadowRadius = 7;
+			public static int TextAppearance_android_shadowDx = 7;
+			
+			// aapt resource value: 8
+			public static int TextAppearance_android_shadowDy = 8;
+			
+			// aapt resource value: 9
+			public static int TextAppearance_android_shadowRadius = 9;
 			
 			// aapt resource value: 3
 			public static int TextAppearance_android_textColor = 3;
+			
+			// aapt resource value: 4
+			public static int TextAppearance_android_textColorHint = 4;
+			
+			// aapt resource value: 5
+			public static int TextAppearance_android_textColorLink = 5;
 			
 			// aapt resource value: 0
 			public static int TextAppearance_android_textSize = 0;
@@ -5698,21 +7196,29 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 1
 			public static int TextAppearance_android_typeface = 1;
 			
-			// aapt resource value: 8
-			public static int TextAppearance_textAllCaps = 8;
+			// aapt resource value: 12
+			public static int TextAppearance_fontFamily = 12;
+			
+			// aapt resource value: 11
+			public static int TextAppearance_textAllCaps = 11;
 			
 			public static int[] TextInputLayout = new int[] {
 					16842906,
 					16843088,
-					2130772275,
-					2130772276,
-					2130772277,
-					2130772278,
-					2130772279,
-					2130772280,
-					2130772281,
-					2130772282,
-					2130772283};
+					2130772316,
+					2130772317,
+					2130772318,
+					2130772319,
+					2130772320,
+					2130772321,
+					2130772322,
+					2130772323,
+					2130772324,
+					2130772325,
+					2130772326,
+					2130772327,
+					2130772328,
+					2130772329};
 			
 			// aapt resource value: 1
 			public static int TextInputLayout_android_hint = 1;
@@ -5747,32 +7253,51 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 2
 			public static int TextInputLayout_hintTextAppearance = 2;
 			
+			// aapt resource value: 13
+			public static int TextInputLayout_passwordToggleContentDescription = 13;
+			
+			// aapt resource value: 12
+			public static int TextInputLayout_passwordToggleDrawable = 12;
+			
+			// aapt resource value: 11
+			public static int TextInputLayout_passwordToggleEnabled = 11;
+			
+			// aapt resource value: 14
+			public static int TextInputLayout_passwordToggleTint = 14;
+			
+			// aapt resource value: 15
+			public static int TextInputLayout_passwordToggleTintMode = 15;
+			
 			public static int[] Toolbar = new int[] {
 					16842927,
 					16843072,
-					2130772009,
+					2130772005,
+					2130772008,
 					2130772012,
-					2130772016,
+					2130772024,
+					2130772025,
+					2130772026,
+					2130772027,
 					2130772028,
 					2130772029,
-					2130772030,
 					2130772031,
-					2130772033,
-					2130772195,
-					2130772196,
-					2130772197,
-					2130772198,
-					2130772199,
-					2130772200,
-					2130772201,
-					2130772202,
-					2130772203,
-					2130772204,
-					2130772205,
-					2130772206,
-					2130772207,
-					2130772208,
-					2130772209};
+					2130772226,
+					2130772227,
+					2130772228,
+					2130772229,
+					2130772230,
+					2130772231,
+					2130772232,
+					2130772233,
+					2130772234,
+					2130772235,
+					2130772236,
+					2130772237,
+					2130772238,
+					2130772239,
+					2130772240,
+					2130772241,
+					2130772242};
 			
 			// aapt resource value: 0
 			public static int Toolbar_android_gravity = 0;
@@ -5780,14 +7305,20 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 1
 			public static int Toolbar_android_minHeight = 1;
 			
-			// aapt resource value: 19
-			public static int Toolbar_collapseContentDescription = 19;
+			// aapt resource value: 21
+			public static int Toolbar_buttonGravity = 21;
 			
-			// aapt resource value: 18
-			public static int Toolbar_collapseIcon = 18;
+			// aapt resource value: 23
+			public static int Toolbar_collapseContentDescription = 23;
+			
+			// aapt resource value: 22
+			public static int Toolbar_collapseIcon = 22;
 			
 			// aapt resource value: 6
 			public static int Toolbar_contentInsetEnd = 6;
+			
+			// aapt resource value: 10
+			public static int Toolbar_contentInsetEndWithActions = 10;
 			
 			// aapt resource value: 7
 			public static int Toolbar_contentInsetLeft = 7;
@@ -5798,63 +7329,69 @@ namespace SuaveControls.MaterialForms.Android
 			// aapt resource value: 5
 			public static int Toolbar_contentInsetStart = 5;
 			
+			// aapt resource value: 9
+			public static int Toolbar_contentInsetStartWithNavigation = 9;
+			
 			// aapt resource value: 4
 			public static int Toolbar_logo = 4;
 			
-			// aapt resource value: 22
-			public static int Toolbar_logoDescription = 22;
-			
-			// aapt resource value: 17
-			public static int Toolbar_maxButtonHeight = 17;
-			
-			// aapt resource value: 21
-			public static int Toolbar_navigationContentDescription = 21;
+			// aapt resource value: 26
+			public static int Toolbar_logoDescription = 26;
 			
 			// aapt resource value: 20
-			public static int Toolbar_navigationIcon = 20;
+			public static int Toolbar_maxButtonHeight = 20;
 			
-			// aapt resource value: 9
-			public static int Toolbar_popupTheme = 9;
+			// aapt resource value: 25
+			public static int Toolbar_navigationContentDescription = 25;
+			
+			// aapt resource value: 24
+			public static int Toolbar_navigationIcon = 24;
+			
+			// aapt resource value: 11
+			public static int Toolbar_popupTheme = 11;
 			
 			// aapt resource value: 3
 			public static int Toolbar_subtitle = 3;
 			
-			// aapt resource value: 11
-			public static int Toolbar_subtitleTextAppearance = 11;
+			// aapt resource value: 13
+			public static int Toolbar_subtitleTextAppearance = 13;
 			
-			// aapt resource value: 24
-			public static int Toolbar_subtitleTextColor = 24;
+			// aapt resource value: 28
+			public static int Toolbar_subtitleTextColor = 28;
 			
 			// aapt resource value: 2
 			public static int Toolbar_title = 2;
 			
-			// aapt resource value: 16
-			public static int Toolbar_titleMarginBottom = 16;
-			
 			// aapt resource value: 14
-			public static int Toolbar_titleMarginEnd = 14;
+			public static int Toolbar_titleMargin = 14;
 			
-			// aapt resource value: 13
-			public static int Toolbar_titleMarginStart = 13;
+			// aapt resource value: 18
+			public static int Toolbar_titleMarginBottom = 18;
+			
+			// aapt resource value: 16
+			public static int Toolbar_titleMarginEnd = 16;
 			
 			// aapt resource value: 15
-			public static int Toolbar_titleMarginTop = 15;
+			public static int Toolbar_titleMarginStart = 15;
+			
+			// aapt resource value: 17
+			public static int Toolbar_titleMarginTop = 17;
+			
+			// aapt resource value: 19
+			public static int Toolbar_titleMargins = 19;
 			
 			// aapt resource value: 12
-			public static int Toolbar_titleMargins = 12;
+			public static int Toolbar_titleTextAppearance = 12;
 			
-			// aapt resource value: 10
-			public static int Toolbar_titleTextAppearance = 10;
-			
-			// aapt resource value: 23
-			public static int Toolbar_titleTextColor = 23;
+			// aapt resource value: 27
+			public static int Toolbar_titleTextColor = 27;
 			
 			public static int[] View = new int[] {
 					16842752,
 					16842970,
-					2130772210,
-					2130772211,
-					2130772212};
+					2130772243,
+					2130772244,
+					2130772245};
 			
 			// aapt resource value: 1
 			public static int View_android_focusable = 1;
@@ -5873,8 +7410,8 @@ namespace SuaveControls.MaterialForms.Android
 			
 			public static int[] ViewBackgroundHelper = new int[] {
 					16842964,
-					2130772213,
-					2130772214};
+					2130772246,
+					2130772247};
 			
 			// aapt resource value: 0
 			public static int ViewBackgroundHelper_android_background = 0;

--- a/src/SuaveControls.MaterialForms.Android/SuaveControls.MaterialForms.Android.csproj
+++ b/src/SuaveControls.MaterialForms.Android/SuaveControls.MaterialForms.Android.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\NuGet.Build.Packaging.0.2.0\build\NuGet.Build.Packaging.props" Condition="Exists('..\packages\NuGet.Build.Packaging.0.2.0\build\NuGet.Build.Packaging.props')" />
+  <Import Project="..\packages\Xamarin.Forms.2.5.1.444934\build\netstandard1.0\Xamarin.Forms.props" Condition="Exists('..\packages\Xamarin.Forms.2.5.1.444934\build\netstandard1.0\Xamarin.Forms.props')" />
+  <Import Project="..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.props" Condition="Exists('..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -16,7 +17,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
@@ -39,7 +40,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FormsViewGroup, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.3.4.247\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.5.1.444934\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Mono.Android" />
@@ -48,41 +49,74 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
+    <Reference Include="Xamarin.Android.Arch.Core.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xamarin.Android.Arch.Core.Common.1.0.0\lib\MonoAndroid80\Xamarin.Android.Arch.Core.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Arch.Lifecycle.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xamarin.Android.Arch.Lifecycle.Common.1.0.3\lib\MonoAndroid80\Xamarin.Android.Arch.Lifecycle.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Arch.Lifecycle.Runtime, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xamarin.Android.Arch.Lifecycle.Runtime.1.0.3\lib\MonoAndroid80\Xamarin.Android.Arch.Lifecycle.Runtime.dll</HintPath>
+    </Reference>
     <Reference Include="Xamarin.Android.Support.Animated.Vector.Drawable, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.Animated.Vector.Drawable.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.27.0.2\lib\MonoAndroid81\Xamarin.Android.Support.Animated.Vector.Drawable.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Annotations, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xamarin.Android.Support.Annotations.27.0.2\lib\MonoAndroid81\Xamarin.Android.Support.Annotations.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Compat, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xamarin.Android.Support.Compat.27.0.2\lib\MonoAndroid81\Xamarin.Android.Support.Compat.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Core.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xamarin.Android.Support.Core.UI.27.0.2\lib\MonoAndroid81\Xamarin.Android.Support.Core.UI.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Core.Utils, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xamarin.Android.Support.Core.Utils.27.0.2\lib\MonoAndroid81\Xamarin.Android.Support.Core.Utils.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Design, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Android.Support.Design.23.3.0\lib\MonoAndroid43\Xamarin.Android.Support.Design.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.Design.27.0.2\lib\MonoAndroid81\Xamarin.Android.Support.Design.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Fragment, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xamarin.Android.Support.Fragment.27.0.2\lib\MonoAndroid81\Xamarin.Android.Support.Fragment.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Media.Compat, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xamarin.Android.Support.Media.Compat.27.0.2\lib\MonoAndroid81\Xamarin.Android.Support.Media.Compat.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Transition, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xamarin.Android.Support.Transition.27.0.2\lib\MonoAndroid81\Xamarin.Android.Support.Transition.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v4, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Android.Support.v4.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v4.27.0.2\lib\MonoAndroid81\Xamarin.Android.Support.v4.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.AppCompat, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Android.Support.v7.AppCompat.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v7.AppCompat.27.0.2\lib\MonoAndroid81\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.CardView, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Android.Support.v7.CardView.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.CardView.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v7.CardView.27.0.2\lib\MonoAndroid81\Xamarin.Android.Support.v7.CardView.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.MediaRouter, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Android.Support.v7.MediaRouter.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.MediaRouter.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v7.MediaRouter.27.0.2\lib\MonoAndroid81\Xamarin.Android.Support.v7.MediaRouter.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v7.Palette, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xamarin.Android.Support.v7.Palette.27.0.2\lib\MonoAndroid81\Xamarin.Android.Support.v7.Palette.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.RecyclerView, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Android.Support.v7.RecyclerView.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.RecyclerView.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v7.RecyclerView.27.0.2\lib\MonoAndroid81\Xamarin.Android.Support.v7.RecyclerView.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Vector.Drawable, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.Vector.Drawable.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.Vector.Drawable.27.0.2\lib\MonoAndroid81\Xamarin.Android.Support.Vector.Drawable.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Core, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.3.4.247\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.5.1.444934\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.3.4.247\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.5.1.444934\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.Android, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.3.4.247\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.5.1.444934\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.3.4.247\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.5.1.444934\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -97,7 +131,9 @@
     <Compile Include="Renderers\MaterialButtonRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Resources\AboutResources.txt" />
   </ItemGroup>
   <ItemGroup>
@@ -111,15 +147,55 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-  <Import Project="..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets'))" />
-    <Error Condition="!Exists('..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets'))" />
+    <Error Condition="!Exists('..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.props'))" />
+    <Error Condition="!Exists('..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Android.Support.Annotations.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Annotations.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Android.Support.Annotations.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Annotations.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Android.Arch.Core.Common.1.0.0\build\MonoAndroid80\Xamarin.Android.Arch.Core.Common.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Android.Arch.Core.Common.1.0.0\build\MonoAndroid80\Xamarin.Android.Arch.Core.Common.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Android.Arch.Lifecycle.Common.1.0.3\build\MonoAndroid80\Xamarin.Android.Arch.Lifecycle.Common.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Android.Arch.Lifecycle.Common.1.0.3\build\MonoAndroid80\Xamarin.Android.Arch.Lifecycle.Common.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Android.Arch.Lifecycle.Runtime.1.0.3\build\MonoAndroid80\Xamarin.Android.Arch.Lifecycle.Runtime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Android.Arch.Lifecycle.Runtime.1.0.3\build\MonoAndroid80\Xamarin.Android.Arch.Lifecycle.Runtime.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Android.Support.Compat.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Compat.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Android.Support.Compat.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Compat.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Android.Support.Core.UI.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Core.UI.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Android.Support.Core.UI.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Core.UI.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Android.Support.Core.Utils.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Core.Utils.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Android.Support.Core.Utils.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Core.Utils.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Android.Support.Fragment.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Fragment.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Android.Support.Fragment.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Fragment.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Android.Support.Media.Compat.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Media.Compat.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Android.Support.Media.Compat.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Media.Compat.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Android.Support.Transition.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Transition.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Android.Support.Transition.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Transition.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Android.Support.v4.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v4.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Android.Support.v4.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v4.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Android.Support.v7.CardView.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.CardView.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Android.Support.v7.CardView.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.CardView.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Android.Support.v7.Palette.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.Palette.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Android.Support.v7.Palette.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.Palette.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Android.Support.v7.RecyclerView.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.RecyclerView.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Android.Support.v7.RecyclerView.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.RecyclerView.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Android.Support.Vector.Drawable.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Vector.Drawable.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Android.Support.Vector.Drawable.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Vector.Drawable.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Animated.Vector.Drawable.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Animated.Vector.Drawable.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Android.Support.v7.AppCompat.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.AppCompat.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Android.Support.v7.AppCompat.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.AppCompat.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Android.Support.Design.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Design.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Android.Support.Design.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Design.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Android.Support.v7.MediaRouter.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.MediaRouter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Android.Support.v7.MediaRouter.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.MediaRouter.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Forms.2.5.1.444934\build\netstandard1.0\Xamarin.Forms.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Forms.2.5.1.444934\build\netstandard1.0\Xamarin.Forms.props'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Forms.2.5.1.444934\build\netstandard1.0\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Forms.2.5.1.444934\build\netstandard1.0\Xamarin.Forms.targets'))" />
   </Target>
-  <Import Project="..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Import Project="..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.targets" Condition="Exists('..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Annotations.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Annotations.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Annotations.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Annotations.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Arch.Core.Common.1.0.0\build\MonoAndroid80\Xamarin.Android.Arch.Core.Common.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Core.Common.1.0.0\build\MonoAndroid80\Xamarin.Android.Arch.Core.Common.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Arch.Lifecycle.Common.1.0.3\build\MonoAndroid80\Xamarin.Android.Arch.Lifecycle.Common.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Lifecycle.Common.1.0.3\build\MonoAndroid80\Xamarin.Android.Arch.Lifecycle.Common.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Arch.Lifecycle.Runtime.1.0.3\build\MonoAndroid80\Xamarin.Android.Arch.Lifecycle.Runtime.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Lifecycle.Runtime.1.0.3\build\MonoAndroid80\Xamarin.Android.Arch.Lifecycle.Runtime.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Compat.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Compat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Compat.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Compat.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Core.UI.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Core.UI.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Core.UI.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Core.UI.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Core.Utils.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Core.Utils.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Core.Utils.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Core.Utils.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Fragment.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Fragment.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Fragment.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Fragment.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Media.Compat.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Media.Compat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Media.Compat.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Media.Compat.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Transition.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Transition.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Transition.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Transition.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v4.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v4.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v4.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v4.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v7.CardView.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.CardView.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.CardView.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.CardView.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v7.Palette.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.Palette.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.Palette.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.Palette.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v7.RecyclerView.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.RecyclerView.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.RecyclerView.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.RecyclerView.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Vector.Drawable.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Vector.Drawable.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Vector.Drawable.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Animated.Vector.Drawable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Animated.Vector.Drawable.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v7.AppCompat.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.AppCompat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.AppCompat.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.AppCompat.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Design.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Design.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Design.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Design.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v7.MediaRouter.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.MediaRouter.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.MediaRouter.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.MediaRouter.targets')" />
+  <Import Project="..\packages\Xamarin.Forms.2.5.1.444934\build\netstandard1.0\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.5.1.444934\build\netstandard1.0\Xamarin.Forms.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
@@ -127,5 +203,4 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <Import Project="..\packages\NuGet.Build.Packaging.0.2.0\build\NuGet.Build.Packaging.targets" Condition="Exists('..\packages\NuGet.Build.Packaging.0.2.0\build\NuGet.Build.Packaging.targets')" />
 </Project>

--- a/src/SuaveControls.MaterialForms.Android/packages.config
+++ b/src/SuaveControls.MaterialForms.Android/packages.config
@@ -1,13 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NuGet.Build.Packaging" version="0.2.0" targetFramework="monoandroid80" developmentDependency="true" />
-  <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="23.3.0" targetFramework="monoandroid71" />
-  <package id="Xamarin.Android.Support.Design" version="23.3.0" targetFramework="monoandroid71" />
-  <package id="Xamarin.Android.Support.v4" version="23.3.0" targetFramework="monoandroid71" />
-  <package id="Xamarin.Android.Support.v7.AppCompat" version="23.3.0" targetFramework="monoandroid71" />
-  <package id="Xamarin.Android.Support.v7.CardView" version="23.3.0" targetFramework="monoandroid71" />
-  <package id="Xamarin.Android.Support.v7.MediaRouter" version="23.3.0" targetFramework="monoandroid71" />
-  <package id="Xamarin.Android.Support.v7.RecyclerView" version="23.3.0" targetFramework="monoandroid71" />
-  <package id="Xamarin.Android.Support.Vector.Drawable" version="23.3.0" targetFramework="monoandroid71" />
-  <package id="Xamarin.Forms" version="2.3.4.247" targetFramework="monoandroid71" />
+  <package id="NuGet.Build.Packaging" version="0.2.2" targetFramework="monoandroid81" developmentDependency="true" />
+  <package id="Xamarin.Android.Arch.Core.Common" version="1.0.0" targetFramework="monoandroid81" />
+  <package id="Xamarin.Android.Arch.Lifecycle.Common" version="1.0.3" targetFramework="monoandroid81" />
+  <package id="Xamarin.Android.Arch.Lifecycle.Runtime" version="1.0.3" targetFramework="monoandroid81" />
+  <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="27.0.2" targetFramework="monoandroid81" />
+  <package id="Xamarin.Android.Support.Annotations" version="27.0.2" targetFramework="monoandroid81" />
+  <package id="Xamarin.Android.Support.Compat" version="27.0.2" targetFramework="monoandroid81" />
+  <package id="Xamarin.Android.Support.Core.UI" version="27.0.2" targetFramework="monoandroid81" />
+  <package id="Xamarin.Android.Support.Core.Utils" version="27.0.2" targetFramework="monoandroid81" />
+  <package id="Xamarin.Android.Support.Design" version="27.0.2" targetFramework="monoandroid81" />
+  <package id="Xamarin.Android.Support.Fragment" version="27.0.2" targetFramework="monoandroid81" />
+  <package id="Xamarin.Android.Support.Media.Compat" version="27.0.2" targetFramework="monoandroid81" />
+  <package id="Xamarin.Android.Support.Transition" version="27.0.2" targetFramework="monoandroid81" />
+  <package id="Xamarin.Android.Support.v4" version="27.0.2" targetFramework="monoandroid81" />
+  <package id="Xamarin.Android.Support.v7.AppCompat" version="27.0.2" targetFramework="monoandroid81" />
+  <package id="Xamarin.Android.Support.v7.CardView" version="27.0.2" targetFramework="monoandroid81" />
+  <package id="Xamarin.Android.Support.v7.MediaRouter" version="27.0.2" targetFramework="monoandroid81" />
+  <package id="Xamarin.Android.Support.v7.Palette" version="27.0.2" targetFramework="monoandroid81" />
+  <package id="Xamarin.Android.Support.v7.RecyclerView" version="27.0.2" targetFramework="monoandroid81" />
+  <package id="Xamarin.Android.Support.Vector.Drawable" version="27.0.2" targetFramework="monoandroid81" />
+  <package id="Xamarin.Forms" version="2.5.1.444934" targetFramework="monoandroid81" />
 </packages>

--- a/src/SuaveControls.MaterialForms.UWP/SuaveControls.MaterialForms.UWP.csproj
+++ b/src/SuaveControls.MaterialForms.UWP/SuaveControls.MaterialForms.UWP.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>SuaveControls.MaterialForms.UWP</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.15063.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.10586.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.16299.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -117,10 +117,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>5.3.3</Version>
+      <Version>6.0.8</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
-      <Version>2.3.4.247</Version>
+      <Version>2.5.1.444934</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup />

--- a/src/SuaveControls.MaterialForms.iOS/SuaveControls.MaterialForms.iOS.csproj
+++ b/src/SuaveControls.MaterialForms.iOS/SuaveControls.MaterialForms.iOS.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\NuGet.Build.Packaging.0.2.0\build\NuGet.Build.Packaging.props" Condition="Exists('..\packages\NuGet.Build.Packaging.0.2.0\build\NuGet.Build.Packaging.props')" />
+  <Import Project="..\packages\Xamarin.Forms.2.5.1.444934\build\netstandard1.0\Xamarin.Forms.props" Condition="Exists('..\packages\Xamarin.Forms.2.5.1.444934\build\netstandard1.0\Xamarin.Forms.props')" />
+  <Import Project="..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.props" Condition="Exists('..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -38,16 +39,16 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.Forms.Core, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.5.1.444934\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.5.1.444934\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.iOS, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.5.1.444934\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.5.1.444934\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
@@ -74,12 +75,15 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
-  <Import Project="..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets'))" />
+    <Error Condition="!Exists('..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.props'))" />
+    <Error Condition="!Exists('..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Forms.2.5.1.444934\build\netstandard1.0\Xamarin.Forms.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Forms.2.5.1.444934\build\netstandard1.0\Xamarin.Forms.props'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Forms.2.5.1.444934\build\netstandard1.0\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Forms.2.5.1.444934\build\netstandard1.0\Xamarin.Forms.targets'))" />
   </Target>
-  <Import Project="..\packages\NuGet.Build.Packaging.0.2.0\build\NuGet.Build.Packaging.targets" Condition="Exists('..\packages\NuGet.Build.Packaging.0.2.0\build\NuGet.Build.Packaging.targets')" />
+  <Import Project="..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.targets" Condition="Exists('..\packages\NuGet.Build.Packaging.0.2.2\build\NuGet.Build.Packaging.targets')" />
+  <Import Project="..\packages\Xamarin.Forms.2.5.1.444934\build\netstandard1.0\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.5.1.444934\build\netstandard1.0\Xamarin.Forms.targets')" />
 </Project>

--- a/src/SuaveControls.MaterialForms.iOS/packages.config
+++ b/src/SuaveControls.MaterialForms.iOS/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NuGet.Build.Packaging" version="0.2.0" targetFramework="xamarinios10" developmentDependency="true" />
-  <package id="Xamarin.Forms" version="2.3.4.247" targetFramework="xamarinios10" />
+  <package id="NuGet.Build.Packaging" version="0.2.2" targetFramework="xamarinios10" developmentDependency="true" />
+  <package id="Xamarin.Forms" version="2.5.1.444934" targetFramework="xamarinios10" />
 </packages>

--- a/src/SuaveControls.MaterialForms.sln
+++ b/src/SuaveControls.MaterialForms.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26430.15
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SuaveControls.MaterialForms", "SuaveControls.MaterialForms\SuaveControls.MaterialForms.csproj", "{67F9D3A8-F71E-4428-913F-C37AE82CDB24}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SuaveControls.MaterialForms", "SuaveControls.MaterialForms\SuaveControls.MaterialForms.csproj", "{67F9D3A8-F71E-4428-913F-C37AE82CDB24}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SuaveControls.MaterialForms.Android", "SuaveControls.MaterialForms.Android\SuaveControls.MaterialForms.Android.csproj", "{C646A031-62AB-47AD-B584-B96270522CCD}"
 EndProject
@@ -108,5 +108,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F2CDAB81-3492-4AFC-872E-B5D7E4C4F7CB}
 	EndGlobalSection
 EndGlobal

--- a/src/SuaveControls.MaterialForms/SuaveControls.MaterialForms.csproj
+++ b/src/SuaveControls.MaterialForms/SuaveControls.MaterialForms.csproj
@@ -1,113 +1,44 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\NuGet.Build.Packaging.0.2.0\build\NuGet.Build.Packaging.props" Condition="Exists('..\packages\NuGet.Build.Packaging.0.2.0\build\NuGet.Build.Packaging.props')" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{67F9D3A8-F71E-4428-913F-C37AE82CDB24}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>SuaveControls.MaterialForms</RootNamespace>
-    <AssemblyName>SuaveControls.MaterialForms</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Compile Include="BorderlessDatePicker.cs" />
-    <Compile Include="BorderlessEditor.cs" />
-    <Compile Include="BorderlessEntry.cs" />
-    <Compile Include="BorderlessPicker.cs" />
-    <Compile Include="BorderlessTimePicker.cs" />
-    <Compile Include="MaterialDatePicker.xaml.cs">
+    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.2" />
+    <PackageReference Include="Xamarin.Forms" Version="2.5.1.444934" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="MaterialDatePicker.xaml.cs">
       <DependentUpon>MaterialDatePicker.xaml</DependentUpon>
     </Compile>
-    <Compile Include="MaterialEntry.xaml.cs">
+    <Compile Update="MaterialEntry.xaml.cs">
       <DependentUpon>MaterialEntry.xaml</DependentUpon>
     </Compile>
-    <Compile Include="MaterialPicker.xaml.cs">
+    <Compile Update="MaterialPicker.xaml.cs">
       <DependentUpon>MaterialPicker.xaml</DependentUpon>
     </Compile>
-    <Compile Include="MaterialTimePicker.xaml.cs">
+    <Compile Update="MaterialTimePicker.xaml.cs">
       <DependentUpon>MaterialTimePicker.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="MaterialButton.cs" />
   </ItemGroup>
+
   <ItemGroup>
-    <Reference Include="Xamarin.Forms.Core, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Forms.Platform, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Forms.Xaml, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
-    </Reference>
+    <Compile Update="MaterialDatePicker.xaml.cs">
+      <DependentUpon>MaterialDatePicker.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="MaterialEntry.xaml.cs">
+      <DependentUpon>MaterialEntry.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="MaterialPicker.xaml.cs">
+      <DependentUpon>MaterialPicker.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="MaterialTimePicker.xaml.cs">
+      <DependentUpon>MaterialTimePicker.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="MaterialEntry.xaml">
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="MaterialPicker.xaml">
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="MaterialDatePicker.xaml">
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="MaterialTimePicker.xaml">
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-  </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Import Project="..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets'))" />
-  </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
-  <Import Project="..\packages\NuGet.Build.Packaging.0.2.0\build\NuGet.Build.Packaging.targets" Condition="Exists('..\packages\NuGet.Build.Packaging.0.2.0\build\NuGet.Build.Packaging.targets')" />
+  
+
 </Project>


### PR DESCRIPTION
Issue #27.
UWP project min framework version has been updated because UWP supports .Net Standard 2.0 only from 10.0.16299 (Fall creators update) ([.Net standard versions](https://github.com/dotnet/standard/blob/master/docs/versions.md))